### PR TITLE
Add modular content builder and batch pack

### DIFF
--- a/src/lib/groq.ts
+++ b/src/lib/groq.ts
@@ -64,3 +64,155 @@ export async function generateHooks(niche: string, tone: string, product?: strin
     return text.trim().split("\n").map((h: string) => h.trim()).filter(Boolean);
   }
   
+
+export interface HookScene {
+  visual: string;
+  text: string;
+}
+
+export async function generateHookScenes(niche: string, tone: string) {
+  const prompt = `Kamu adalah pakar kreator konten pendek. Buat 5 ide hook video dengan format:\nVisual: <deskripsi adegan 1-2 detik>\nText: <kalimat pembuka>.\nGaya: ${tone}. Niche atau produk: ${niche}. Jangan pakai bullet atau nomor.`;
+
+  const resp = await fetch("https://api.groq.com/openai/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${process.env.GROQ_API_KEY}`,
+    },
+    body: JSON.stringify({
+      model: "llama-3.3-70b-versatile",
+      messages: [{ role: "user", content: prompt }],
+      stream: false,
+      temperature: 0.3,
+      max_tokens: 512,
+    }),
+  });
+
+  if (!resp.ok) throw new Error(`Groq API error ${resp.status}`);
+  const json = await resp.json();
+  const text: string = json.choices?.[0]?.message?.content || "";
+
+  return text
+    .split(/\n+/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .reduce<HookScene[]>((acc, line) => {
+      const match = line.match(/Visual:\s*(.*?)\s*Text:\s*(.*)/i);
+      if (match) {
+        acc.push({ visual: match[1], text: match[2] });
+      }
+      return acc;
+    }, []);
+}
+
+export interface ContentScript {
+  hook: string;
+  problem: string;
+  agitation: string;
+  solution: string;
+  cta: string;
+}
+
+export async function generateContentScript(
+  niche: string,
+  style: string,
+  product?: string
+) {
+  const base = `Buat skrip video 15-60 detik dengan format Hook-Problem-Agitation-Solution-CTA. Gaya penyampaian ${style}. Niche atau produk: ${niche}${
+    product ? ", fokus pada produk: " + product : ""
+  }. Jawab dengan format:\nHook: ...\nProblem: ...\nAgitation: ...\nSolution: ...\nCTA: ...`;
+
+  const resp = await fetch("https://api.groq.com/openai/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${process.env.GROQ_API_KEY}`,
+    },
+    body: JSON.stringify({
+      model: "llama-3.3-70b-versatile",
+      messages: [{ role: "user", content: base }],
+      stream: false,
+      temperature: 0.3,
+      max_tokens: 512,
+    }),
+  });
+
+  if (!resp.ok) throw new Error(`Groq API error ${resp.status}`);
+  const json = await resp.json();
+  const text: string = json.choices?.[0]?.message?.content || "";
+
+  const get = (label: string) => {
+    const m = text.match(new RegExp(`${label}:\\s*(.*)`, "i"));
+    return m ? m[1].trim() : "";
+  };
+
+  return {
+    hook: get("Hook"),
+    problem: get("Problem"),
+    agitation: get("Agitation"),
+    solution: get("Solution"),
+    cta: get("CTA"),
+  } as ContentScript;
+}
+
+export interface BatchItem {
+  title: string;
+  visual: string;
+  text: string;
+  hook: string;
+  problem: string;
+  solution: string;
+  cta: string;
+  thumbnail: string;
+  vo: string;
+}
+
+export async function generateBatchPack(
+  brand: string,
+  product: string,
+  audience: string,
+  count = 10
+) {
+  const prompt = `Buat ${count} ide konten pendek untuk brand ${brand} yang menjual ${product}. Audiens utama: ${audience}. Format per konten:\nJudul: ...\nVisual: ...\nTextHook: ...\nHook: ...\nProblem: ...\nSolution: ...\nCTA: ...\nThumbnail: ...\nVO: ...`;
+
+  const resp = await fetch("https://api.groq.com/openai/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${process.env.GROQ_API_KEY}`,
+    },
+    body: JSON.stringify({
+      model: "llama-3.3-70b-versatile",
+      messages: [{ role: "user", content: prompt }],
+      stream: false,
+      temperature: 0.4,
+      max_tokens: 2048,
+    }),
+  });
+
+  if (!resp.ok) throw new Error(`Groq API error ${resp.status}`);
+  const json = await resp.json();
+  const text: string = json.choices?.[0]?.message?.content || "";
+
+  const items: BatchItem[] = [];
+  const parts = text.split(/\n(?=Judul:)/i).filter(Boolean);
+  for (const part of parts) {
+    const get = (label: string) => {
+      const m = part.match(new RegExp(`${label}:\\s*(.*)`, "i"));
+      return m ? m[1].trim() : "";
+    };
+    items.push({
+      title: get("Judul"),
+      visual: get("Visual"),
+      text: get("TextHook"),
+      hook: get("Hook"),
+      problem: get("Problem"),
+      solution: get("Solution"),
+      cta: get("CTA"),
+      thumbnail: get("Thumbnail"),
+      vo: get("VO"),
+    });
+  }
+  return items;
+}
+

--- a/src/pages/api/generate-batch.ts
+++ b/src/pages/api/generate-batch.ts
@@ -1,0 +1,17 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { generateBatchPack } from "@/lib/groq";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).end("Method Not Allowed");
+
+  const { brand = "", product = "", audience = "", count = 10 } = req.body;
+  if (!brand || !product) return res.status(400).json({ error: "Brand and product required" });
+
+  try {
+    const batch = await generateBatchPack(brand, product, audience, Number(count));
+    res.json({ batch });
+  } catch (err: any) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
+}

--- a/src/pages/api/generate-scenes.ts
+++ b/src/pages/api/generate-scenes.ts
@@ -1,0 +1,17 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { generateHookScenes } from "@/lib/groq";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).end("Method Not Allowed");
+
+  const { niche = "", tone = "edukatif" } = req.body;
+  if (!niche) return res.status(400).json({ error: "Niche required" });
+
+  try {
+    const data = await generateHookScenes(niche, tone);
+    res.json({ hooks: data });
+  } catch (err: any) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
+}

--- a/src/pages/api/generate-script.ts
+++ b/src/pages/api/generate-script.ts
@@ -1,0 +1,17 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { generateContentScript } from "@/lib/groq";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).end("Method Not Allowed");
+
+  const { niche = "", style = "soft-sell", product = "" } = req.body;
+  if (!niche) return res.status(400).json({ error: "Niche required" });
+
+  try {
+    const script = await generateContentScript(niche, style, product);
+    res.json({ script });
+  } catch (err: any) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
+}

--- a/src/pages/batch.tsx
+++ b/src/pages/batch.tsx
@@ -1,0 +1,85 @@
+import Head from "next/head";
+import { useState } from "react";
+
+export default function Batch() {
+  const [brand, setBrand] = useState("");
+  const [product, setProduct] = useState("");
+  const [audience, setAudience] = useState("");
+  const [count, setCount] = useState(10);
+  const [loading, setLoading] = useState(false);
+  const [items, setItems] = useState<any[]>([]);
+
+  async function handleGenerate(e: React.FormEvent) {
+    e.preventDefault();
+    if (!brand || !product) return;
+    setLoading(true);
+    setItems([]);
+    try {
+      const r = await fetch("/api/generate-batch", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ brand, product, audience, count }),
+      });
+      const data = await r.json();
+      setItems(data.batch || []);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <>
+      <Head>
+        <title>HookFreak • Batch Pack</title>
+      </Head>
+      <main className="main-wrapper">
+        <section className="hero">
+          <h1 className="logo-text">
+            Hook<span>Freak</span>
+          </h1>
+          <p className="subtitle">Batch Pack Generator</p>
+        </section>
+        <section className="form-section">
+          <form onSubmit={handleGenerate} className="hook-form">
+            <label>
+              <span className="form-label">Nama Brand</span>
+              <input type="text" value={brand} onChange={(e) => setBrand(e.target.value)} className="niche-input" />
+            </label>
+            <label>
+              <span className="form-label">Produk</span>
+              <input type="text" value={product} onChange={(e) => setProduct(e.target.value)} className="niche-input" />
+            </label>
+            <label>
+              <span className="form-label">Audiens</span>
+              <input type="text" value={audience} onChange={(e) => setAudience(e.target.value)} className="niche-input" />
+            </label>
+            <label>
+              <span className="form-label">Jumlah Konten</span>
+              <input type="number" value={count} min={1} max={30} onChange={(e) => setCount(Number(e.target.value))} className="niche-input" />
+            </label>
+            <button type="submit" disabled={loading} className="generate-button">
+              {loading ? "Menghasilkan..." : "Generate Batch"}
+            </button>
+          </form>
+          {items.length > 0 && (
+            <div className="results" style={{ whiteSpace: "pre-wrap" }}>
+              {items.map((it, idx) => (
+                <div key={idx} style={{ marginBottom: 24 }}>
+                  <p><strong>{it.title}</strong></p>
+                  <p>Visual: {it.visual}</p>
+                  <p>Text Hook: {it.text}</p>
+                  <p>Hook: {it.hook}</p>
+                  <p>Problem: {it.problem}</p>
+                  <p>Solution: {it.solution}</p>
+                  <p>CTA: {it.cta}</p>
+                  <p>Thumbnail: {it.thumbnail}</p>
+                  <p>VO: {it.vo}</p>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+      </main>
+    </>
+  );
+}

--- a/src/pages/builder.tsx
+++ b/src/pages/builder.tsx
@@ -1,0 +1,91 @@
+import Head from "next/head";
+import { useState } from "react";
+
+export default function Builder() {
+  const [niche, setNiche] = useState("");
+  const [style, setStyle] = useState("soft-sell");
+  const [product, setProduct] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<any>(null);
+
+  async function handleGenerate(e: React.FormEvent) {
+    e.preventDefault();
+    if (!niche) return;
+    setLoading(true);
+    setResult(null);
+    try {
+      const r = await fetch("/api/generate-script", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ niche, style, product }),
+      });
+      const data = await r.json();
+      setResult(data.script);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <>
+      <Head>
+        <title>HookFreak • Content Builder</title>
+      </Head>
+      <main className="main-wrapper">
+        <section className="hero">
+          <h1 className="logo-text">
+            Hook<span>Freak</span>
+          </h1>
+          <p className="subtitle">Content Builder</p>
+        </section>
+        <section className="form-section">
+          <form onSubmit={handleGenerate} className="hook-form">
+            <label>
+              <span className="form-label">Apa yang mau dijual?</span>
+              <input
+                type="text"
+                value={niche}
+                onChange={(e) => setNiche(e.target.value)}
+                className="niche-input"
+              />
+            </label>
+            <label>
+              <span className="form-label">Gaya penyampaian</span>
+              <select
+                value={style}
+                onChange={(e) => setStyle(e.target.value)}
+                className="tone-select"
+              >
+                <option value="hard-sell">Hard Sell</option>
+                <option value="soft-sell">Soft Sell</option>
+                <option value="storytelling">Storytelling</option>
+                <option value="humor">Humor</option>
+                <option value="shock">Shock</option>
+              </select>
+            </label>
+            <label>
+              <span className="form-label">Produk (opsional)</span>
+              <input
+                type="text"
+                value={product}
+                onChange={(e) => setProduct(e.target.value)}
+              />
+            </label>
+            <button type="submit" disabled={loading} className="generate-button">
+              {loading ? "Menghasilkan..." : "Generate Script"}
+            </button>
+          </form>
+          {result && (
+            <div className="results" style={{ whiteSpace: "pre-wrap" }}>
+              <p><strong>Hook:</strong> {result.hook}</p>
+              <p><strong>Problem:</strong> {result.problem}</p>
+              <p><strong>Agitation:</strong> {result.agitation}</p>
+              <p><strong>Solution:</strong> {result.solution}</p>
+              <p><strong>CTA:</strong> {result.cta}</p>
+            </div>
+          )}
+        </section>
+      </main>
+    </>
+  );
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -16,10 +16,18 @@ export default function Landing() {
           <h1 className="logo-text">
             Hook<span>Freak</span>
           </h1>
-          <p className="subtitle">Viral Hook Generator untuk TikTok &amp; Reels</p>
-          <Link href="/generator" className="cta-button">
-            Coba Sekarang →
-          </Link>
+          <p className="subtitle">Toolkit Konten TikTok/Reels</p>
+          <div style={{display:"flex",gap:12,flexWrap:"wrap",justifyContent:"center"}}>
+            <Link href="/generator" className="cta-button">
+              Hook Generator
+            </Link>
+            <Link href="/builder" className="cta-button">
+              Content Builder
+            </Link>
+            <Link href="/batch" className="cta-button">
+              Batch Pack
+            </Link>
+          </div>
         </section>
         <section className="features">
           <div className="feature">


### PR DESCRIPTION
## Summary
- add more Groq helpers for visual hook, script, and batch generation
- expose new API endpoints for script and batch
- implement `/builder` page for full Hook-Problem-Solution CTA script
- implement `/batch` page for generating multiple content packs
- update landing links for the new modules

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68405d6902cc832e9c297cf2bc5dd835