### PR TITLE
Add video sales hook builder

### DIFF
--- a/readme.MD
+++ b/readme.MD
@@ -1,12 +1,12 @@
-# HookFreak – Viral Hook Generator
+# HookFreak – Video Sales Hook Builder
 
-Generate 10 hook viral < 12 kata untuk TikTok/IG berdasarkan niche & tone.
-Powered by Groq LLAMA‑3‑70B.
+Bangun skrip video jualan TikTok, Reels, dan Shorts dalam sekali klik. Hasilkan visual hook, teks pembuka, skrip 30 detik, dan saran frame secara langsung.
 
-Sekarang setiap hook punya tombol Like/Dislike supaya kamu bisa kasih feedback instan.
-Tampilan juga diperhalus dengan animasi sederhana.
+Setiap permintaan memberi tiga versi alternatif supaya kamu bisa pilih yang paling pas.
 
 ## Cara jalan
 1.  `cp .env.example .env.local` lalu isi `GROQ_API_KEY`
 2.  `npm i`
 3.  `npm run dev`
+
+Kamu bisa langsung buka `/builder` untuk mencoba generator utama.

--- a/src/pages/api/generate-script.ts
+++ b/src/pages/api/generate-script.ts
@@ -1,15 +1,23 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { generateContentScript } from "@/lib/groq";
+import { generateSalesHooks } from "@/lib/groq";
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
   if (req.method !== "POST") return res.status(405).end("Method Not Allowed");
 
-  const { niche = "", style = "soft-sell", product = "" } = req.body;
-  if (!niche) return res.status(400).json({ error: "Niche required" });
+  const {
+    description = "",
+    audience = "",
+    style = "soft-sell",
+  } = req.body;
+  if (!description)
+    return res.status(400).json({ error: "Description required" });
 
   try {
-    const script = await generateContentScript(niche, style, product);
-    res.json({ script });
+    const hooks = await generateSalesHooks(description, audience, style);
+    res.json({ hooks });
   } catch (err: any) {
     console.error(err);
     res.status(500).json({ error: err.message });

--- a/src/pages/builder.tsx
+++ b/src/pages/builder.tsx
@@ -2,25 +2,25 @@ import Head from "next/head";
 import { useState } from "react";
 
 export default function Builder() {
-  const [niche, setNiche] = useState("");
+  const [description, setDescription] = useState("");
+  const [audience, setAudience] = useState("");
   const [style, setStyle] = useState("soft-sell");
-  const [product, setProduct] = useState("");
   const [loading, setLoading] = useState(false);
-  const [result, setResult] = useState<any>(null);
+  const [result, setResult] = useState<any[] | null>(null);
 
   async function handleGenerate(e: React.FormEvent) {
     e.preventDefault();
-    if (!niche) return;
+    if (!description) return;
     setLoading(true);
     setResult(null);
     try {
       const r = await fetch("/api/generate-script", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ niche, style, product }),
+        body: JSON.stringify({ description, audience, style }),
       });
       const data = await r.json();
-      setResult(data.script);
+      setResult(data.hooks || []);
     } finally {
       setLoading(false);
     }
@@ -29,28 +29,37 @@ export default function Builder() {
   return (
     <>
       <Head>
-        <title>HookFreak • Content Builder</title>
+        <title>HookFreak • Video Sales Hook Builder</title>
       </Head>
       <main className="main-wrapper">
         <section className="hero">
           <h1 className="logo-text">
             Hook<span>Freak</span>
           </h1>
-          <p className="subtitle">Content Builder</p>
+          <p className="subtitle">Video Sales Hook Builder</p>
         </section>
         <section className="form-section">
           <form onSubmit={handleGenerate} className="hook-form">
             <label>
-              <span className="form-label">Apa yang mau dijual?</span>
+              <span className="form-label">Deskripsi Produk</span>
               <input
                 type="text"
-                value={niche}
-                onChange={(e) => setNiche(e.target.value)}
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
                 className="niche-input"
               />
             </label>
             <label>
-              <span className="form-label">Gaya penyampaian</span>
+              <span className="form-label">Target Audiens</span>
+              <input
+                type="text"
+                value={audience}
+                onChange={(e) => setAudience(e.target.value)}
+                className="niche-input"
+              />
+            </label>
+            <label>
+              <span className="form-label">Gaya Konten</span>
               <select
                 value={style}
                 onChange={(e) => setStyle(e.target.value)}
@@ -63,25 +72,20 @@ export default function Builder() {
                 <option value="shock">Shock</option>
               </select>
             </label>
-            <label>
-              <span className="form-label">Produk (opsional)</span>
-              <input
-                type="text"
-                value={product}
-                onChange={(e) => setProduct(e.target.value)}
-              />
-            </label>
             <button type="submit" disabled={loading} className="generate-button">
               {loading ? "Menghasilkan..." : "Generate Script"}
             </button>
           </form>
           {result && (
             <div className="results" style={{ whiteSpace: "pre-wrap" }}>
-              <p><strong>Hook:</strong> {result.hook}</p>
-              <p><strong>Problem:</strong> {result.problem}</p>
-              <p><strong>Agitation:</strong> {result.agitation}</p>
-              <p><strong>Solution:</strong> {result.solution}</p>
-              <p><strong>CTA:</strong> {result.cta}</p>
+              {result.map((r, idx) => (
+                <div key={idx} style={{ marginBottom: 24 }}>
+                  <p><strong>Visual Hook:</strong> {r.visualHook}</p>
+                  <p><strong>Teks Hook:</strong> {r.textHook}</p>
+                  <p><strong>Script:</strong> {r.script}</p>
+                  <p><strong>Frame:</strong> {r.frames}</p>
+                </div>
+              ))}
             </div>
           )}
         </section>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,13 +2,40 @@ import Head from "next/head";
 import Link from "next/link";
 
 export default function Landing() {
+  const examples = [
+    {
+      visual: "Close-up wajah kaget, tiba-tiba munculkan botol serum",
+      text: "Jerawat datang lagi? Bentar, coba ini dulu!",
+      script:
+        "Hook -- Problem -- Agitation -- Solution -- CTA",
+      frame:
+        "Hook: close-up wajah, Problem: tunjuk jerawat, Agitation: ekspresi frustasi, Solution: tampilkan produk, CTA: ajak cek link bio",
+    },
+    {
+      visual: "Before-after meja berantakan lalu rapi dalam satu swipe",
+      text: "Gini caranya meja kerja keliatan premium!",
+      script:
+        "Hook -- Problem -- Agitation -- Solution -- CTA",
+      frame:
+        "Hook: sapu kamera ke meja, Problem: tunjuk kekacauan, Agitation: geleng kepala, Solution: pasang organizer, CTA: kode diskon di caption",
+    },
+    {
+      visual: "Gerakan tangan cepat pasang casing HP warna neon",
+      text: "Pengen hp keliatan mahal tanpa beli baru?",
+      script:
+        "Hook -- Problem -- Agitation -- Solution -- CTA",
+      frame:
+        "Hook: tangan masang casing, Problem: hp polos bikin bosan, Agitation: jari mengetuk kesal, Solution: tunjuk casing warna neon, CTA: swipe up untuk beli",
+    },
+  ];
+
   return (
     <>
       <Head>
-        <title>HookFreak • Viral Hook Generator</title>
+        <title>HookFreak • Video Sales Hook Builder</title>
         <meta
           name="description"
-          content="Bikin hook TikTok viral kurang dari 12 kata. Gratis dan cepat."
+          content="Bangun hook video jualan yang nancep dalam hitungan detik."
         />
       </Head>
       <main className="landing-wrapper">
@@ -16,33 +43,45 @@ export default function Landing() {
           <h1 className="logo-text">
             Hook<span>Freak</span>
           </h1>
-          <p className="subtitle">Toolkit Konten TikTok/Reels</p>
-          <div style={{display:"flex",gap:12,flexWrap:"wrap",justifyContent:"center"}}>
-            <Link href="/generator" className="cta-button">
-              Hook Generator
+          <p className="subtitle">Video Sales Hook Builder</p>
+          <form action="/builder" className="hero-form">
+            <input
+              name="description"
+              placeholder="Apa yang kamu jual?"
+              className="niche-input"
+            />
+            <select name="style" className="tone-select">
+              <option value="storytelling">Storytelling</option>
+              <option value="hard-sell">Hard Sell</option>
+              <option value="soft-sell">Soft Sell</option>
+              <option value="humor">Humor</option>
+              <option value="shock">Shock</option>
+            </select>
+            <button type="submit" className="cta-button">
+              Lihat Hasil Cepat
+            </button>
+          </form>
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginTop: 16 }}>
+            <Link href="/builder?persona=ugc" className="cta-outline">
+              Saya UGC Creator
             </Link>
-            <Link href="/builder" className="cta-button">
-              Content Builder
+            <Link href="/builder?persona=brand" className="cta-outline">
+              Saya Pemilik Brand
             </Link>
-            <Link href="/batch" className="cta-button">
-              Batch Pack
+            <Link href="/builder?persona=freelancer" className="cta-outline">
+              Saya Freelancer Marketing
             </Link>
           </div>
         </section>
-        <section className="features">
-          <div className="feature">
-            <h3>⚡ Cepat &amp; Gratis</h3>
-            <p>Generate 10 hook kurang dari 12 kata cuma dengan 1 klik.</p>
-          </div>
-          <div className="feature">
-            <h3>🤖 Powered by AI</h3>
-            <p>Ditenagai model LLAMA-3-70B via Groq untuk hasil tajam.</p>
-          </div>
-          <div className="feature">
-            <h3>🎯 CTR Tinggi</h3>
-            <p>Hook didesain khusus untuk bikin penonton berhenti scroll.</p>
-          </div>
-        </section>
+        {examples.map((ex, idx) => (
+          <section key={idx} className="example">
+            <h3>Contoh #{idx + 1}</h3>
+            <p><strong>Adegan Pembuka:</strong> {ex.visual}</p>
+            <p><strong>Teks Hook:</strong> {ex.text}</p>
+            <p><strong>Script:</strong> {ex.script}</p>
+            <p><strong>Frame:</strong> {ex.frame}</p>
+          </section>
+        ))}
       </main>
     </>
   );


### PR DESCRIPTION
## Summary
- implement sales hook generation in API and Groq helper
- update builder page to accept product description, audience, and style
- show multiple hook versions with frame suggestions
- redesign landing page for new positioning with example outputs and quick form
- refresh readme

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684061d5fa78832ea3e0556616370255