### PR TITLE
Overhaul landing page for HookFreak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+.env*

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,87 +1,128 @@
 import Head from "next/head";
+import { useState } from "react";
 import Link from "next/link";
 
 export default function Landing() {
+  const [product, setProduct] = useState("");
+  const [style, setStyle] = useState("storytelling");
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<any | null>(null);
+
   const examples = [
     {
-      visual: "Close-up wajah kaget, tiba-tiba munculkan botol serum",
-      text: "Jerawat datang lagi? Bentar, coba ini dulu!",
-      script:
-        "Hook -- Problem -- Agitation -- Solution -- CTA",
-      frame:
-        "Hook: close-up wajah, Problem: tunjuk jerawat, Agitation: ekspresi frustasi, Solution: tampilkan produk, CTA: ajak cek link bio",
+      visual: "Tetesin serum ke punggung tangan sambil close-up",
+      text: "Kulit kusam? Nih trik biar cerah tanpa ribet!",
+      script: "Hook -- Problem -- Solution -- CTA",
     },
     {
-      visual: "Before-after meja berantakan lalu rapi dalam satu swipe",
-      text: "Gini caranya meja kerja keliatan premium!",
-      script:
-        "Hook -- Problem -- Agitation -- Solution -- CTA",
-      frame:
-        "Hook: sapu kamera ke meja, Problem: tunjuk kekacauan, Agitation: geleng kepala, Solution: pasang organizer, CTA: kode diskon di caption",
+      visual: "Tangan pasang holder HP di motor, shot cepat",
+      text: "Jalan sambil jualan? Gini cara gampangnya!",
+      script: "Hook -- Problem -- Solution -- CTA",
     },
     {
-      visual: "Gerakan tangan cepat pasang casing HP warna neon",
-      text: "Pengen hp keliatan mahal tanpa beli baru?",
-      script:
-        "Hook -- Problem -- Agitation -- Solution -- CTA",
-      frame:
-        "Hook: tangan masang casing, Problem: hp polos bikin bosan, Agitation: jari mengetuk kesal, Solution: tunjuk casing warna neon, CTA: swipe up untuk beli",
+      visual: "Close up snack rendah kalori digigit",
+      text: "Cerita gagal diet gara-gara ngemil? Dengerin ini",
+      script: "Hook -- Problem -- Solution -- CTA",
     },
   ];
+
+  async function handleGenerate(e: React.FormEvent) {
+    e.preventDefault();
+    if (!product) return;
+    setLoading(true);
+    setResult(null);
+    try {
+      const r = await fetch("/api/generate-script", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ description: product, style, audience: "" }),
+      });
+      const data = await r.json();
+      if (data.hooks && data.hooks.length) {
+        setResult(data.hooks[0]);
+        localStorage.setItem("hf-temp", JSON.stringify(data.hooks[0]));
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
 
   return (
     <>
       <Head>
-        <title>HookFreak • Video Sales Hook Builder</title>
+        <title>HookFreak</title>
         <meta
           name="description"
-          content="Bangun hook video jualan yang nancep dalam hitungan detik."
+          content="Bikin video jualan nancep di detik pertama."
         />
       </Head>
       <main className="landing-wrapper">
         <section className="landing-hero">
-          <h1 className="logo-text">
-            Hook<span>Freak</span>
-          </h1>
-          <p className="subtitle">Video Sales Hook Builder</p>
-          <form action="/builder" className="hero-form">
-            <input
-              name="description"
-              placeholder="Apa yang kamu jual?"
-              className="niche-input"
-            />
-            <select name="style" className="tone-select">
+          <div className="hero-grid">
+            <div className="hero-visual">
+              <img src="/og-cover.png" alt="preview" style={{ width: "100%", borderRadius: 12 }} />
+            </div>
+            <div className="hero-content">
+              <h1 className="logo-text">Hook<span>Freak</span></h1>
+              <p className="subtitle">Bikin opening video yang langsung jualan</p>
+              <form onSubmit={handleGenerate} className="hero-form">
+                <input
+                  value={product}
+                  onChange={(e) => setProduct(e.target.value)}
+                  placeholder="Apa produk yang kamu jual?"
+                  className="niche-input"
+                />
+                <select
+                  value={style}
+                  onChange={(e) => setStyle(e.target.value)}
+                  className="tone-select"
+                >
               <option value="storytelling">Storytelling</option>
+              <option value="edukatif">Edukatif</option>
               <option value="hard-sell">Hard Sell</option>
               <option value="soft-sell">Soft Sell</option>
-              <option value="humor">Humor</option>
-              <option value="shock">Shock</option>
+              <option value="lucu">Lucu</option>
+              <option value="fomo">FOMO</option>
             </select>
-            <button type="submit" className="cta-button">
-              Lihat Hasil Cepat
-            </button>
-          </form>
-          <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginTop: 16 }}>
-            <Link href="/builder?persona=ugc" className="cta-outline">
-              Saya UGC Creator
-            </Link>
-            <Link href="/builder?persona=brand" className="cta-outline">
-              Saya Pemilik Brand
-            </Link>
-            <Link href="/builder?persona=freelancer" className="cta-outline">
-              Saya Freelancer Marketing
-            </Link>
+                <button type="submit" className="cta-button" disabled={loading}>
+                  {loading ? "Sebentar..." : "Bikin skrip konten pertama saya"}
+                </button>
+              </form>
+              {result && (
+                <div className="result-preview">
+                  <p><strong>Visual Hook:</strong> {result.visualHook}</p>
+                  <p><strong>Teks Hook:</strong> {result.textHook}</p>
+                  <p><strong>Script:</strong> {result.script}</p>
+                  <p><strong>Frame:</strong> {result.frames}</p>
+                </div>
+              )}
+            </div>
           </div>
         </section>
-        {examples.map((ex, idx) => (
-          <section key={idx} className="example">
-            <h3>Contoh #{idx + 1}</h3>
-            <p><strong>Adegan Pembuka:</strong> {ex.visual}</p>
-            <p><strong>Teks Hook:</strong> {ex.text}</p>
-            <p><strong>Script:</strong> {ex.script}</p>
-            <p><strong>Frame:</strong> {ex.frame}</p>
-          </section>
-        ))}
+
+        <section className="examples">
+          {examples.map((ex, idx) => (
+            <div key={idx} className="example-item">
+              <div className="example-visual">{ex.visual}</div>
+              <div className="example-text">
+                <p className="hook-text">{ex.text}</p>
+                <p className="script-text">{ex.script}</p>
+              </div>
+            </div>
+          ))}
+        </section>
+
+        <div style={{ marginTop: 40 }}>
+          <Link href="/builder" className="cta-button">
+            Coba generator lengkap
+          </Link>
+        </div>
+
+        <footer className="footer" style={{ marginTop: 80 }}>
+          <Link href="/builder" className="cta-button">
+            Mulai gratis sekarang
+          </Link>
+        </footer>
       </main>
     </>
   );

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -410,3 +410,82 @@
   font-size: 0.95rem;
   line-height: 1.6;
 }
+
+/* Landing revamp */
+.hero-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  align-items: center;
+}
+
+.hero-content {
+  max-width: 420px;
+}
+
+@media (min-width: 768px) {
+  .hero-grid {
+    flex-direction: row;
+    align-items: flex-start;
+    gap: 48px;
+  }
+  .hero-visual,
+  .hero-content {
+    flex: 1;
+  }
+}
+
+.result-preview {
+  background: #181818;
+  padding: 16px;
+  border-radius: 12px;
+  margin-top: 24px;
+}
+
+.examples {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  width: 100%;
+  max-width: 800px;
+}
+
+.example-item {
+  background: #181818;
+  padding: 16px;
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.example-visual {
+  background: #000;
+  border: 1px solid #333;
+  border-radius: 8px;
+  padding: 16px;
+  font-size: 0.9rem;
+  color: #ccc;
+}
+
+.example-text .hook-text {
+  margin: 0 0 8px;
+  font-weight: 600;
+}
+
+.example-text .script-text {
+  margin: 0;
+  color: #a1a1a1;
+}
+
+@media (min-width: 768px) {
+  .example-item {
+    flex-direction: row;
+  }
+  .example-visual {
+    width: 45%;
+  }
+  .example-text {
+    width: 55%;
+  }
+}


### PR DESCRIPTION
## Summary
- redesign landing page with conversion-first copy
- add interactive script generator on the hero
- show sample outputs directly on the page
- style layout for two-column hero and example previews
- add gitignore

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684065ee2b94832ebce3f02f48d1af18