### PR TITLE
Overhaul landing page for HookFreak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+.env*

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link";
+
+export default function Footer() {
+  return (
+    <footer className="site-footer">
+      <div className="foot-links">
+        <Link href="/privacy">Privacy Policy</Link>
+        <Link href="/terms">Terms</Link>
+        <Link href="mailto:hello@hookfreak.com">Kontak</Link>
+      </div>
+      <p className="foot-small">
+        Built with love for content creators • HookFreak v2.0 © 2025
+      </p>
+    </footer>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+export default function Navbar() {
+  const [scrolled, setScrolled] = useState(false);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const handle = () => setScrolled(window.scrollY > 50);
+    window.addEventListener("scroll", handle);
+    return () => window.removeEventListener("scroll", handle);
+  }, []);
+
+  return (
+    <>
+      <nav className={`navbar ${scrolled ? "solid" : "transparent"}`}>
+        <Link href="/" className="navbar-logo">
+          HookFreak
+        </Link>
+        <div className="navbar-links">
+          <Link href="#examples">Contoh Konten</Link>
+          <Link href="/builder" className="cta-small">
+            Mulai Sekarang
+          </Link>
+        </div>
+        <button
+          className="navbar-toggle"
+          onClick={() => setOpen(true)}
+          aria-label="Buka menu"
+        >
+          &#9776;
+        </button>
+      </nav>
+      {open && (
+        <div className="mobile-menu">
+          <button
+            className="close"
+            aria-label="Tutup menu"
+            onClick={() => setOpen(false)}
+          >
+            &times;
+          </button>
+          <Link href="/builder" onClick={() => setOpen(false)}>
+            Buka Builder
+          </Link>
+          <Link href="#examples" onClick={() => setOpen(false)}>
+            Contoh Konten
+          </Link>
+          <Link href="#about" onClick={() => setOpen(false)}>
+            Tentang Produk
+          </Link>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/pages/builder.tsx
+++ b/src/pages/builder.tsx
@@ -30,6 +30,7 @@ export default function Builder() {
     <>
       <Head>
         <title>HookFreak • Video Sales Hook Builder</title>
+        <meta name="robots" content="noindex" />
       </Head>
       <main className="main-wrapper">
         <section className="hero">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,87 +1,153 @@
 import Head from "next/head";
+import { useEffect, useState } from "react";
 import Link from "next/link";
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
 
 export default function Landing() {
+  const [product, setProduct] = useState("");
+  const [style, setStyle] = useState("storytelling");
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<any | null>(null);
+
+  useEffect(() => {
+    const saved = localStorage.getItem("hf-temp");
+    if (saved && !result) {
+      try {
+        setResult(JSON.parse(saved));
+      } catch {}
+    }
+  }, []);
+
   const examples = [
     {
-      visual: "Close-up wajah kaget, tiba-tiba munculkan botol serum",
-      text: "Jerawat datang lagi? Bentar, coba ini dulu!",
-      script:
-        "Hook -- Problem -- Agitation -- Solution -- CTA",
-      frame:
-        "Hook: close-up wajah, Problem: tunjuk jerawat, Agitation: ekspresi frustasi, Solution: tampilkan produk, CTA: ajak cek link bio",
+      visual: "Tetesin serum ke punggung tangan sambil close-up",
+      text: "Kulit kusam? Nih trik biar cerah tanpa ribet!",
+      script: "Hook -- Problem -- Solution -- CTA",
     },
     {
-      visual: "Before-after meja berantakan lalu rapi dalam satu swipe",
-      text: "Gini caranya meja kerja keliatan premium!",
-      script:
-        "Hook -- Problem -- Agitation -- Solution -- CTA",
-      frame:
-        "Hook: sapu kamera ke meja, Problem: tunjuk kekacauan, Agitation: geleng kepala, Solution: pasang organizer, CTA: kode diskon di caption",
+      visual: "Tangan pasang holder HP di motor, shot cepat",
+      text: "Jalan sambil jualan? Gini cara gampangnya!",
+      script: "Hook -- Problem -- Solution -- CTA",
     },
     {
-      visual: "Gerakan tangan cepat pasang casing HP warna neon",
-      text: "Pengen hp keliatan mahal tanpa beli baru?",
-      script:
-        "Hook -- Problem -- Agitation -- Solution -- CTA",
-      frame:
-        "Hook: tangan masang casing, Problem: hp polos bikin bosan, Agitation: jari mengetuk kesal, Solution: tunjuk casing warna neon, CTA: swipe up untuk beli",
+      visual: "Close up snack rendah kalori digigit",
+      text: "Cerita gagal diet gara-gara ngemil? Dengerin ini",
+      script: "Hook -- Problem -- Solution -- CTA",
     },
   ];
+
+  async function handleGenerate(e: React.FormEvent) {
+    e.preventDefault();
+    if (!product) return;
+    setLoading(true);
+    setResult(null);
+    try {
+      const r = await fetch("/api/generate-script", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ description: product, style, audience: "" }),
+      });
+      const data = await r.json();
+      if (data.hooks && data.hooks.length) {
+        setResult(data.hooks[0]);
+        localStorage.setItem("hf-temp", JSON.stringify(data.hooks[0]));
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
 
   return (
     <>
       <Head>
-        <title>HookFreak • Video Sales Hook Builder</title>
+        <title>Buat Skrip Konten Jualan TikTok & Reels dalam 30 Detik – HookFreak</title>
         <meta
           name="description"
-          content="Bangun hook video jualan yang nancep dalam hitungan detik."
+          content="HookFreak bantu kamu bikin pembuka video yang nancep & bikin orang beli. Visual + teks + skrip lengkap."
         />
+        <meta property="og:image" content="/og-cover.png" />
       </Head>
+      <Navbar />
       <main className="landing-wrapper">
         <section className="landing-hero">
-          <h1 className="logo-text">
-            Hook<span>Freak</span>
-          </h1>
-          <p className="subtitle">Video Sales Hook Builder</p>
-          <form action="/builder" className="hero-form">
-            <input
-              name="description"
-              placeholder="Apa yang kamu jual?"
-              className="niche-input"
-            />
-            <select name="style" className="tone-select">
-              <option value="storytelling">Storytelling</option>
-              <option value="hard-sell">Hard Sell</option>
-              <option value="soft-sell">Soft Sell</option>
-              <option value="humor">Humor</option>
-              <option value="shock">Shock</option>
-            </select>
-            <button type="submit" className="cta-button">
-              Lihat Hasil Cepat
-            </button>
-          </form>
-          <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginTop: 16 }}>
-            <Link href="/builder?persona=ugc" className="cta-outline">
-              Saya UGC Creator
-            </Link>
-            <Link href="/builder?persona=brand" className="cta-outline">
-              Saya Pemilik Brand
-            </Link>
-            <Link href="/builder?persona=freelancer" className="cta-outline">
-              Saya Freelancer Marketing
-            </Link>
+          <div className="hero-grid">
+            <div className="hero-visual">
+              <img src="/og-cover.png" alt="preview" style={{ width: "100%", borderRadius: 12 }} />
+            </div>
+            <div className="hero-content">
+              <h1 className="logo-text">Hook<span>Freak</span></h1>
+              <p className="subtitle">Bikin opening video yang langsung jualan</p>
+              <form onSubmit={handleGenerate} className="hero-form">
+                <input
+                  value={product}
+                  onChange={(e) => setProduct(e.target.value)}
+                  placeholder="Produk kamu apa?"
+                  className="niche-input"
+                />
+                <select
+                  value={style}
+                  onChange={(e) => setStyle(e.target.value)}
+                  className="tone-select"
+                >
+                  <option value="storytelling">Storytelling</option>
+                  <option value="edukatif">Edukatif</option>
+                  <option value="hard-sell">Hard Sell</option>
+                  <option value="soft-sell">Soft Sell</option>
+                  <option value="lucu">Lucu</option>
+                  <option value="fomo">FOMO</option>
+                </select>
+                <button type="submit" className="cta-button" disabled={loading}>
+                  {loading ? "Sebentar..." : "Bikin Konten Saya"}
+                </button>
+              </form>
+              <div className="result-section">
+                {loading && (
+                  <div className="result-grid">
+                    <div className="result-text skeleton" style={{ height: 120 }} />
+                    <div className="result-visual skeleton" style={{ height: 120 }} />
+                  </div>
+                )}
+                {result && !loading && (
+                  <div className="result-grid">
+                    <div className="result-text">
+                      <p><strong>Adegan Pembuka:</strong> {result.visualHook}</p>
+                      <button className="regen" onClick={handleGenerate} disabled={loading}>Generate ulang</button>
+                      <p><strong>Kalimat Subtitle:</strong> {result.textHook}</p>
+                      <button className="regen" onClick={handleGenerate} disabled={loading}>Generate ulang</button>
+                      <p><strong>Isi Video:</strong> {result.script}</p>
+                      <button className="regen" onClick={handleGenerate} disabled={loading}>Generate ulang</button>
+                      <p><strong>Ajakan Tindakan:</strong> {result.frames}</p>
+                      <button className="regen" onClick={handleGenerate} disabled={loading}>Generate ulang</button>
+                    </div>
+                    <div className="result-visual">
+                      <div className="visual-mock">{result.visualHook}</div>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
           </div>
         </section>
-        {examples.map((ex, idx) => (
-          <section key={idx} className="example">
-            <h3>Contoh #{idx + 1}</h3>
-            <p><strong>Adegan Pembuka:</strong> {ex.visual}</p>
-            <p><strong>Teks Hook:</strong> {ex.text}</p>
-            <p><strong>Script:</strong> {ex.script}</p>
-            <p><strong>Frame:</strong> {ex.frame}</p>
-          </section>
-        ))}
+
+        <section className="examples">
+          {examples.map((ex, idx) => (
+            <div key={idx} className="example-item">
+              <div className="example-visual">{ex.visual}</div>
+              <div className="example-text">
+                <p className="hook-text">{ex.text}</p>
+                <p className="script-text">{ex.script}</p>
+              </div>
+            </div>
+          ))}
+        </section>
+
+        <div style={{ marginTop: 40 }}>
+          <Link href="/builder" className="cta-button">
+            Coba generator lengkap
+          </Link>
+        </div>
+        <Footer />
       </main>
     </>
   );

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -384,6 +384,19 @@
   background-color: #16a34a;
 }
 
+.cta-small {
+  padding: 8px 16px;
+  background-color: #22c55e;
+  color: #000;
+  border-radius: 6px;
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+.cta-small:hover {
+  background-color: #16a34a;
+}
+
 .features {
   display: flex;
   flex-direction: column;
@@ -409,4 +422,242 @@
   color: #cccccc;
   font-size: 0.95rem;
   line-height: 1.6;
+}
+
+/* Landing revamp */
+.hero-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  align-items: center;
+}
+
+.hero-content {
+  max-width: 420px;
+}
+
+@media (min-width: 768px) {
+  .hero-grid {
+    flex-direction: row;
+    align-items: flex-start;
+    gap: 48px;
+  }
+  .hero-visual,
+  .hero-content {
+    flex: 1;
+  }
+}
+
+.result-preview {
+  background: #181818;
+  padding: 16px;
+  border-radius: 12px;
+  margin-top: 24px;
+}
+
+.examples {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  width: 100%;
+  max-width: 800px;
+}
+
+.example-item {
+  background: #181818;
+  padding: 16px;
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.example-visual {
+  background: #000;
+  border: 1px solid #333;
+  border-radius: 8px;
+  padding: 16px;
+  font-size: 0.9rem;
+  color: #ccc;
+}
+
+.example-text .hook-text {
+  margin: 0 0 8px;
+  font-weight: 600;
+}
+
+.example-text .script-text {
+  margin: 0;
+  color: #a1a1a1;
+}
+
+@media (min-width: 768px) {
+  .example-item {
+    flex-direction: row;
+  }
+  .example-visual {
+    width: 45%;
+  }
+  .example-text {
+    width: 55%;
+  }
+}
+/* Navbar */
+.navbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 20px;
+  z-index: 30;
+  transition: background 0.3s ease, box-shadow 0.3s ease;
+}
+.navbar.transparent {
+  background: transparent;
+}
+.navbar.solid {
+  background: #ffffff;
+  color: #000;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+.navbar a {
+  color: inherit;
+  text-decoration: none;
+  margin-left: 20px;
+  font-weight: 500;
+}
+.navbar-logo {
+  font-weight: 800;
+  font-size: 1.2rem;
+}
+.navbar-toggle {
+  display: none;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+@media (max-width: 640px) {
+  .navbar-links {
+    display: none;
+  }
+  .navbar-toggle {
+    display: block;
+  }
+}
+.mobile-menu {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: #000;
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 24px;
+  z-index: 40;
+}
+.mobile-menu a {
+  color: #fff;
+  font-size: 1.25rem;
+  text-decoration: none;
+}
+.mobile-menu .close {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  font-size: 2rem;
+  background: none;
+  border: none;
+  color: #fff;
+  cursor: pointer;
+}
+
+/* Footer */
+.site-footer {
+  text-align: center;
+  margin-top: 80px;
+  padding: 40px 0;
+  font-size: 0.85rem;
+  color: #a1a1a1;
+  border-top: 1px solid #333;
+}
+.foot-links {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  margin-bottom: 8px;
+}
+.foot-links a {
+  color: inherit;
+  text-decoration: none;
+}
+.foot-small {
+  margin-top: 8px;
+}
+
+/* Result */
+.result-section {
+  margin-top: 24px;
+}
+.result-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+.result-text,
+.result-visual {
+  background: #181818;
+  padding: 16px;
+  border-radius: 12px;
+}
+@media (min-width: 768px) {
+  .result-grid {
+    flex-direction: row;
+  }
+  .result-text,
+  .result-visual {
+    flex: 1;
+  }
+}
+.skeleton {
+  background: linear-gradient(90deg, #262626 25%, #3a3a3a 37%, #262626 63%);
+  background-size: 400% 100%;
+  animation: shimmer 1.2s ease infinite;
+}
+@keyframes shimmer {
+  0% {
+    background-position: 100% 0;
+  }
+  100% {
+    background-position: -100% 0;
+  }
+}
+.regen {
+  margin: 8px 0 16px;
+  background: transparent;
+  border: 1px solid #444;
+  color: #ccc;
+  padding: 6px 12px;
+  border-radius: 6px;
+  font-size: 0.8rem;
+}
+
+/* Sticky CTA on mobile */
+@media (max-width: 640px) {
+  .hero-form {
+    padding-bottom: 56px;
+  }
+  .hero-form .cta-button {
+    position: fixed;
+    bottom: 16px;
+    left: 16px;
+    right: 16px;
+  }
 }


### PR DESCRIPTION
## Summary
- redesign landing page with conversion-first copy
- add interactive script generator on the hero
- show sample outputs directly on the page
- style layout for two-column hero and example previews
- add gitignore
- add responsive navbar, footer, improved layout

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684065ee2b94832ebce3f02f48d1af18