### PR TITLE
Simplify landing page UI

### DIFF
--- a/public/sample-script.txt
+++ b/public/sample-script.txt
@@ -1,0 +1,6 @@
+# Contoh Skrip Video Jualan
+
+1. Buka dengan pertanyaan menggugah minat.
+2. Tunjukkan masalah umum yang dialami pelanggan.
+3. Hadirkan produk Anda sebagai solusi.
+4. Akhiri dengan ajakan aksi singkat.

--- a/src/components/ExampleModal.tsx
+++ b/src/components/ExampleModal.tsx
@@ -1,0 +1,25 @@
+import { FiX } from "react-icons/fi";
+
+interface Props {
+  item: { visual: string; text: string; script: string } | null;
+  onClose: () => void;
+}
+
+export default function ExampleModal({ item, onClose }: Props) {
+  if (!item) return null;
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+        <button className="modal-close" onClick={onClose} aria-label="Tutup">
+          <FiX size={20} />
+        </button>
+        <h3 className="modal-title">{item.text}</h3>
+        <p className="modal-visual">{item.visual}</p>
+        <p className="modal-script">{item.script}</p>
+        <button className="cta-button" onClick={onClose} style={{ marginTop: 16 }}>
+          Gunakan Template
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link";
+import { FiMenu, FiX, FiInfo, FiMail, FiShield } from "react-icons/fi";
+import { useState } from "react";
+
+export default function NavBar() {
+  const [open, setOpen] = useState(false);
+  return (
+    <nav className="navbar">
+      <button
+        className="menu-toggle"
+        onClick={() => setOpen(!open)}
+        aria-label="Toggle menu"
+      >
+        {open ? <FiX size={24} /> : <FiMenu size={24} />}
+      </button>
+      {open && (
+        <div className="menu-panel">
+          <Link href="/about" className="menu-item" onClick={() => setOpen(false)}>
+            <FiInfo /> Tentang
+          </Link>
+          <Link href="/contact" className="menu-item" onClick={() => setOpen(false)}>
+            <FiMail /> Kontak
+          </Link>
+          <Link href="/privacy" className="menu-item" onClick={() => setOpen(false)}>
+            <FiShield /> Kebijakan Privasi
+          </Link>
+        </div>
+      )}
+    </nav>
+  );
+}

--- a/src/components/ScriptModal.tsx
+++ b/src/components/ScriptModal.tsx
@@ -1,0 +1,27 @@
+import { FiX } from "react-icons/fi";
+
+interface Props {
+  open: boolean;
+  content: string;
+  onClose: () => void;
+}
+
+export default function ScriptModal({ open, content, onClose }: Props) {
+  if (!open) return null;
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+        <button className="modal-close" onClick={onClose} aria-label="Tutup">
+          <FiX size={20} />
+        </button>
+        <h3 className="modal-title">Pratinjau Skrip</h3>
+        <pre className="modal-script" style={{ whiteSpace: "pre-wrap" }}>
+          {content}
+        </pre>
+        <a href="/sample-script.txt" download className="cta-button" style={{ marginTop: 16 }}>
+          Unduh File
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,129 +1,54 @@
 import Head from "next/head";
 import { useState } from "react";
-import Link from "next/link";
+import NavBar from "@/components/NavBar";
+import ScriptModal from "@/components/ScriptModal";
 
 export default function Landing() {
-  const [product, setProduct] = useState("");
-  const [style, setStyle] = useState("storytelling");
-  const [loading, setLoading] = useState(false);
-  const [result, setResult] = useState<any | null>(null);
+  const [open, setOpen] = useState(false);
+  const [content, setContent] = useState("");
 
-  const examples = [
-    {
-      visual: "Tetesin serum ke punggung tangan sambil close-up",
-      text: "Kulit kusam? Nih trik biar cerah tanpa ribet!",
-      script: "Hook -- Problem -- Solution -- CTA",
-    },
-    {
-      visual: "Tangan pasang holder HP di motor, shot cepat",
-      text: "Jalan sambil jualan? Gini cara gampangnya!",
-      script: "Hook -- Problem -- Solution -- CTA",
-    },
-    {
-      visual: "Close up snack rendah kalori digigit",
-      text: "Cerita gagal diet gara-gara ngemil? Dengerin ini",
-      script: "Hook -- Problem -- Solution -- CTA",
-    },
-  ];
-
-  async function handleGenerate(e: React.FormEvent) {
-    e.preventDefault();
-    if (!product) return;
-    setLoading(true);
-    setResult(null);
-    try {
-      const r = await fetch("/api/generate-script", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ description: product, style, audience: "" }),
-      });
-      const data = await r.json();
-      if (data.hooks && data.hooks.length) {
-        setResult(data.hooks[0]);
-        localStorage.setItem("hf-temp", JSON.stringify(data.hooks[0]));
-      }
-    } finally {
-      setLoading(false);
-    }
+  async function handleClick() {
+    const res = await fetch("/sample-script.txt");
+    const text = await res.text();
+    setContent(text);
+    setOpen(true);
+    const link = document.createElement("a");
+    link.href = "/sample-script.txt";
+    link.download = "script.txt";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
   }
 
   return (
     <>
       <Head>
         <title>HookFreak</title>
-        <meta
-          name="description"
-          content="Bikin video jualan nancep di detik pertama."
-        />
+        <meta name="description" content="Langsung dapatkan skrip video jualan" />
       </Head>
-      <main className="landing-wrapper">
-        <section className="landing-hero">
-          <div className="hero-grid">
-            <div className="hero-visual">
-              <img src="/og-cover.png" alt="preview" style={{ width: "100%", borderRadius: 12 }} />
-            </div>
-            <div className="hero-content">
-              <h1 className="logo-text">Hook<span>Freak</span></h1>
-              <p className="subtitle">Bikin opening video yang langsung jualan</p>
-              <form onSubmit={handleGenerate} className="hero-form">
-                <input
-                  value={product}
-                  onChange={(e) => setProduct(e.target.value)}
-                  placeholder="Apa produk yang kamu jual?"
-                  className="niche-input"
-                />
-                <select
-                  value={style}
-                  onChange={(e) => setStyle(e.target.value)}
-                  className="tone-select"
-                >
-              <option value="storytelling">Storytelling</option>
-              <option value="edukatif">Edukatif</option>
-              <option value="hard-sell">Hard Sell</option>
-              <option value="soft-sell">Soft Sell</option>
-              <option value="lucu">Lucu</option>
-              <option value="fomo">FOMO</option>
-            </select>
-                <button type="submit" className="cta-button" disabled={loading}>
-                  {loading ? "Sebentar..." : "Bikin skrip konten pertama saya"}
-                </button>
-              </form>
-              {result && (
-                <div className="result-preview">
-                  <p><strong>Visual Hook:</strong> {result.visualHook}</p>
-                  <p><strong>Teks Hook:</strong> {result.textHook}</p>
-                  <p><strong>Script:</strong> {result.script}</p>
-                  <p><strong>Frame:</strong> {result.frames}</p>
-                </div>
-              )}
-            </div>
-          </div>
-        </section>
-
-        <section className="examples">
-          {examples.map((ex, idx) => (
-            <div key={idx} className="example-item">
-              <div className="example-visual">{ex.visual}</div>
-              <div className="example-text">
-                <p className="hook-text">{ex.text}</p>
-                <p className="script-text">{ex.script}</p>
-              </div>
-            </div>
-          ))}
-        </section>
-
-        <div style={{ marginTop: 40 }}>
-          <Link href="/builder" className="cta-button">
-            Coba generator lengkap
-          </Link>
-        </div>
-
+      <NavBar />
+      <main className="landing-wrapper fade-in" style={{ textAlign: "center" }}>
+        <h1 className="logo-text" style={{ marginTop: 80 }}>
+          Hook<span>Freak</span>
+        </h1>
+        <p className="subtitle" style={{ marginTop: 8 }}>
+          Skrip singkat buat jualan lebih cepat
+        </p>
+        <button className="cta-button main-button" onClick={handleClick} style={{ marginTop: 40 }}>
+          Dapatkan Skrip Sekarang
+        </button>
+        <p style={{ marginTop: 16, color: "#a1a1a1" }}>
+          Langsung dapatkan contoh skrip pertama tanpa ribet
+        </p>
         <footer className="footer" style={{ marginTop: 80 }}>
-          <Link href="/builder" className="cta-button">
-            Mulai gratis sekarang
-          </Link>
+          <p style={{ marginBottom: 8 }}>&copy; {new Date().getFullYear()} HookFreak</p>
+          <div>
+            <a href="/privacy" style={{ marginRight: 12, color: "#fff" }}>Kebijakan Privasi</a>
+            <a href="/contact" style={{ color: "#fff" }}>Kontak</a>
+          </div>
         </footer>
       </main>
+      <ScriptModal open={open} onClose={() => setOpen(false)} content={content} />
     </>
   );
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -7,15 +7,14 @@
     font-family: var(--font-main);
   }
   
-  body {
-    /* font-family: ; */
-    margin: 0;
-    padding: 0;
-    background-color: #000000;
-    color: white;
-    font-size: 16px;
-    line-height: 1.6;
-  }
+body {
+  margin: 0;
+  padding: 0;
+  background-color: #000;
+  color: #fff;
+  font-size: 16px;
+  line-height: 1.6;
+}
   
 
   .subtitle {
@@ -153,9 +152,10 @@
   
   .footer {
     margin-top: 60px;
-    font-size: 12px;
-    color: #777;
+    font-size: 0.9rem;
+    color: #ccc;
     text-align: center;
+    line-height: 1.4;
   }
   
   .hook-list {
@@ -384,6 +384,12 @@
   background-color: #16a34a;
 }
 
+.main-button {
+  width: 100%;
+  max-width: 320px;
+  font-size: 1.1rem;
+}
+
 .features {
   display: flex;
   flex-direction: column;
@@ -489,3 +495,115 @@
     width: 55%;
   }
 }
+
+/* New navigation styles */
+.navbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: flex-end;
+  padding: 12px 16px;
+  background: rgba(0, 0, 0, 0.7);
+  z-index: 50;
+}
+.menu-toggle {
+  background: none;
+  border: none;
+  color: #fff;
+  cursor: pointer;
+}
+.menu-panel {
+  position: absolute;
+  top: 48px;
+  right: 16px;
+  background: #111;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
+  min-width: 150px;
+}
+.menu-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  color: #eee;
+  text-decoration: none;
+}
+.menu-item:hover {
+  background: #222;
+}
+
+/* Example carousel */
+.examples {
+  display: flex;
+  overflow-x: auto;
+  gap: 16px;
+  padding-bottom: 8px;
+}
+.examples::-webkit-scrollbar {
+  display: none;
+}
+.example-item {
+  min-width: 240px;
+  border: 1px solid #333;
+  border-radius: 10px;
+  padding: 16px;
+  background: #181818;
+  flex-shrink: 0;
+}
+.example-item:hover {
+  box-shadow: 0 0 0 2px #22c55e33;
+}
+
+/* Modal */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+.modal-content {
+  background: #111;
+  padding: 24px;
+  border-radius: 12px;
+  width: 90%;
+  max-width: 420px;
+  position: relative;
+}
+.modal-close {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: none;
+  border: none;
+  color: #fff;
+  cursor: pointer;
+}
+.modal-title {
+  margin: 0 0 12px;
+  font-size: 1.2rem;
+}
+.modal-visual {
+  color: #ccc;
+  margin-bottom: 8px;
+}
+.modal-script {
+  color: #aaa;
+}
+
+/* Language selector */
+.language-selector {
+  margin-top: 24px;
+}
+
+


### PR DESCRIPTION
## Summary
- add script preview modal and trigger automatic download
- streamline landing page with single call-to-action
- update navbar links to Tentang, Kontak, and Kebijakan Privasi
- create sample script file for quick access
- tweak global styles for cleaner footer and main button

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68406e8605c4832eaf064d3b8d8e7ff3