### PR TITLE
Revamp landing page

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,24 +1,42 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { FiMenu, FiX } from "react-icons/fi";
 
 export default function Navbar() {
   const [open, setOpen] = useState(false);
+  const [scrolled, setScrolled] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 40);
+    window.addEventListener("scroll", onScroll);
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
   return (
-    <nav className="navbar">
-      <Link href="/" className="nav-logo">Hook<span>Freak</span></Link>
-      <button
-        className="nav-toggle"
-        aria-label="Toggle navigation"
-        onClick={() => setOpen(!open)}
-      >
-        {open ? <FiX size={24} /> : <FiMenu size={24} />}
-      </button>
-      <div className={`nav-links ${open ? "show" : ""}`}>
-        <Link href="/generator">Generator</Link>
-        <a href="#login">Login</a>
-        <a href="#signup" className="signup-btn">Daftar</a>
-      </div>
-    </nav>
+    <>
+      <nav className={`navbar ${scrolled ? "scrolled" : ""}`}>
+        <Link href="/" className="nav-logo">
+          Hook<span>Freak</span>
+        </Link>
+        <button
+          className="nav-toggle"
+          aria-label="Toggle navigation"
+          onClick={() => setOpen(!open)}
+        >
+          {open ? <FiX size={24} /> : <FiMenu size={24} />}
+        </button>
+        <div className={`nav-links ${open ? "show" : ""}`}>
+          <Link href="#features">Fitur</Link>
+          <a href="#pricing">Harga</a>
+          <a href="#login" className="login-link">
+            Login
+          </a>
+        </div>
+      </nav>
+      <div
+        className={`nav-overlay ${open ? "show" : ""}`}
+        onClick={() => setOpen(false)}
+      />
+    </>
   );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,52 +1,52 @@
 import Head from "next/head";
 import Navbar from "@/components/Navbar";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 
-export default function Landing() {
-  const [product, setProduct] = useState("");
-  const [style, setStyle] = useState("storytelling");
+export default function Home() {
+  const [niche, setNiche] = useState("");
+  const [tone, setTone] = useState("fear");
   const [loading, setLoading] = useState(false);
-  const [result, setResult] = useState<any | null>(null);
+  const [hooks, setHooks] = useState<string[]>([]);
+  const generatorRef = useRef<HTMLDivElement>(null);
 
-  const examples = [
-    {
-      visual: "Tetesin serum ke punggung tangan sambil close-up",
-      text: "Kulit kusam? Nih trik biar cerah tanpa ribet!",
-      script: "Hook -- Problem -- Solution -- CTA",
-    },
-    {
-      visual: "Tangan pasang holder HP di motor, shot cepat",
-      text: "Jalan sambil jualan? Gini cara gampangnya!",
-      script: "Hook -- Problem -- Solution -- CTA",
-    },
-    {
-      visual: "Close up snack rendah kalori digigit",
-      text: "Cerita gagal diet gara-gara ngemil? Dengerin ini",
-      script: "Hook -- Problem -- Solution -- CTA",
-    },
-  ];
+  const scrollToGenerator = () => {
+    generatorRef.current?.scrollIntoView({ behavior: "smooth" });
+  };
 
   async function handleGenerate(e: React.FormEvent) {
     e.preventDefault();
-    if (!product) return;
+    if (!niche) return;
     setLoading(true);
-    setResult(null);
+    setHooks([]);
     try {
-      const r = await fetch("/api/generate-script", {
+      const r = await fetch("/api/generate-hooks", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ description: product, style, audience: "" }),
+        body: JSON.stringify({ niche, tone, product: "" }),
       });
       const data = await r.json();
-      if (data.hooks && data.hooks.length) {
-        setResult(data.hooks[0]);
-        localStorage.setItem("hf-temp", JSON.stringify(data.hooks[0]));
-      }
+      setHooks(data.hooks || []);
     } finally {
       setLoading(false);
     }
   }
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add("show");
+          }
+        });
+      },
+      { threshold: 0.2 }
+    );
+    const cards = document.querySelectorAll(".hook-card");
+    cards.forEach((c) => observer.observe(c));
+    return () => observer.disconnect();
+  }, [hooks]);
 
   return (
     <>
@@ -56,76 +56,88 @@ export default function Landing() {
           name="description"
           content="Bikin video jualan nancep di detik pertama."
         />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap"
+          rel="stylesheet"
+        />
       </Head>
-      <main className="landing-wrapper">
-        <Navbar />
-        <section className="landing-hero">
-          <div className="hero-grid">
-            <div className="hero-visual">
-              <img src="/og-cover.png" alt="preview" style={{ width: "100%", borderRadius: 12 }} />
-            </div>
-            <div className="hero-content">
-              <h1 className="logo-text">Hook<span>Freak</span></h1>
-              <p className="subtitle">Bikin opening video yang langsung jualan</p>
-              <form onSubmit={handleGenerate} className="hero-form">
-                <input
-                  value={product}
-                  onChange={(e) => setProduct(e.target.value)}
-                  placeholder="Apa produk yang kamu jual?"
-                  className="niche-input"
-                />
-                <select
-                  value={style}
-                  onChange={(e) => setStyle(e.target.value)}
-                  className="tone-select"
-                >
-              <option value="storytelling">Storytelling</option>
-              <option value="edukatif">Edukatif</option>
-              <option value="hard-sell">Hard Sell</option>
-              <option value="soft-sell">Soft Sell</option>
-              <option value="lucu">Lucu</option>
-              <option value="fomo">FOMO</option>
-            </select>
-                <button type="submit" className="generate-button" disabled={loading}>
-                  {loading ? "Sebentar..." : "Bikin skrip konten pertama saya"}
-                </button>
-              </form>
-              {result && (
-                <div className="result-preview">
-                  <p><strong>Visual Hook:</strong> {result.visualHook}</p>
-                  <p><strong>Teks Hook:</strong> {result.textHook}</p>
-                  <p><strong>Script:</strong> {result.script}</p>
-                  <p><strong>Frame:</strong> {result.frames}</p>
-                </div>
-              )}
-            </div>
+      <Navbar />
+
+      <section className="hero-section">
+        <div className="hero-inner">
+          <div className="hero-visual">
+            <img src="https://images.unsplash.com/photo-1517336714731-489689fd1ca8" alt="Laptop 3D" loading="lazy" />
           </div>
-        </section>
-
-        <section className="examples">
-          {examples.map((ex, idx) => (
-            <div key={idx} className="example-item">
-              <div className="example-visual">{ex.visual}</div>
-              <div className="example-text">
-                <p className="hook-text">{ex.text}</p>
-                <p className="script-text">{ex.script}</p>
-              </div>
-            </div>
-          ))}
-        </section>
-
-        <div style={{ marginTop: 40 }}>
-          <Link href="/builder" className="cta-button">
-            Coba generator lengkap
-          </Link>
+          <div className="hero-copy">
+            <h1>
+              Bikin opening video <span className="hl">TikTok & Reels</span> yang
+              viral dalam 1 klik
+            </h1>
+            <button className="cta-primary" onClick={scrollToGenerator}>
+              Mulai Gratis Sekarang
+            </button>
+          </div>
         </div>
+      </section>
 
-        <footer className="footer" style={{ marginTop: 80 }}>
-          <Link href="/builder" className="cta-button">
-            Mulai gratis sekarang
-          </Link>
-        </footer>
-      </main>
+      <section className="features-section" id="features">
+        <div className="feature">
+          <div className="icon">⚡</div>
+          <p>Pembuatan hook instan</p>
+        </div>
+        <div className="feature">
+          <div className="icon">🧠</div>
+          <p>Varian psikologi viral</p>
+        </div>
+        <div className="feature">
+          <div className="icon">🤖</div>
+          <p>Integrasi AI</p>
+        </div>
+      </section>
+
+      <section id="generator" ref={generatorRef} className="generator-section">
+        <form onSubmit={handleGenerate} className="generator-form">
+          <input
+            type="text"
+            placeholder="Contoh: jualan skincare glowing"
+            value={niche}
+            onChange={(e) => setNiche(e.target.value)}
+          />
+          <select value={tone} onChange={(e) => setTone(e.target.value)}>
+            <option value="fear">Fear / Shock</option>
+            <option value="curiosity">Curiosity</option>
+            <option value="confession">Confession</option>
+            <option value="humor">Humor</option>
+            <option value="affiliate">Affiliate Produk</option>
+          </select>
+          <button type="submit" disabled={loading}>
+            {loading ? "Menghasilkan..." : "Generate"}
+          </button>
+        </form>
+
+        {hooks.length > 0 && (
+          <div className="results-grid">
+            {hooks.map((h, i) => (
+              <div key={i} className="hook-card">
+                <h3 className="hook-title">Hook {i + 1}</h3>
+                <p className="hook-desc">{h}</p>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <Link href="/builder" className="cta-secondary">
+          Coba Generator Lengkap
+        </Link>
+      </section>
+
+      <footer className="site-footer">
+        <a href="/privacy">Kebijakan Privasi</a>
+        <a href="/terms">Syarat</a>
+        <a href="mailto:hello@hookfreak.com">Kontak</a>
+      </footer>
     </>
   );
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -561,3 +561,215 @@
   }
 }
 
+/* New landing layout */
+.navbar {
+  position: sticky;
+  top: 0;
+  z-index: 40;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(6px);
+  transition: background 0.3s ease;
+}
+
+.navbar.scrolled {
+  background: rgba(0, 0, 0, 0.9);
+}
+
+.nav-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.8);
+  display: none;
+}
+
+.nav-overlay.show {
+  display: block;
+}
+
+.hero-section {
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #000;
+  padding: 40px 16px;
+}
+
+.hero-inner {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  width: 100%;
+  max-width: 1200px;
+}
+
+.hero-visual img {
+  width: 100%;
+  height: auto;
+  border-radius: 12px;
+}
+
+.hero-copy h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+.hero-copy .hl {
+  color: #00FF6A;
+}
+
+.cta-primary {
+  margin-top: 24px;
+  padding: 16px 32px;
+  font-size: 1rem;
+  background: #00FF6A;
+  color: #000;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  box-shadow: 0 8px 20px rgba(0, 255, 106, 0.35);
+  transition: background 0.2s;
+}
+
+.cta-primary:hover {
+  background: #4dff98;
+}
+
+.features-section {
+  min-height: 600px;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  padding: 60px 16px;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+
+.feature {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  color: #fff;
+  font-size: 16px;
+}
+
+.feature .icon {
+  font-size: 32px;
+  color: #00FF6A;
+}
+
+.generator-section {
+  padding: 60px 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.generator-form {
+  background: #111;
+  padding: 32px;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.4);
+  max-width: 560px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.generator-form input,
+.generator-form select {
+  height: 52px;
+  font-size: 16px;
+  padding: 0 12px;
+  background: #000;
+  border: 1px solid #333;
+  border-radius: 8px;
+  color: #fff;
+}
+
+.generator-form input:focus,
+.generator-form select:focus {
+  outline: 2px solid #00FF6A;
+}
+
+.generator-form button {
+  height: 56px;
+  background: linear-gradient(90deg,#00FF6A,#00ffe6);
+  border: none;
+  border-radius: 8px;
+  color: #000;
+  font-weight: 700;
+  cursor: pointer;
+  transition: opacity 0.3s;
+}
+
+.generator-form button:disabled {
+  background: #222;
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.results-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 24px;
+  margin-top: 40px;
+  width: 100%;
+  max-width: 800px;
+}
+
+.hook-card {
+  opacity: 0;
+  background: #1A1A1A;
+  border: 1px solid #2A2A2A;
+  padding: 24px;
+  border-radius: 12px;
+  transform: translateY(12px);
+  transition: opacity 0.15s ease-out, transform 0.15s ease-out;
+}
+
+.hook-card.show {
+  opacity: 1;
+  transform: none;
+}
+
+.hook-title {
+  margin: 0 0 8px;
+  font-size: 18px;
+  font-weight: 700;
+  color: #fff;
+}
+
+.hook-desc {
+  margin: 0;
+  color: #ccc;
+  font-size: 14px;
+}
+
+.cta-secondary {
+  margin-top: 40px;
+  padding: 12px 24px;
+  border: 2px solid #00FF6A;
+  border-radius: 8px;
+  color: #00FF6A;
+  text-decoration: none;
+  transition: background 0.2s;
+}
+
+.cta-secondary:hover {
+  background: #00FF6A;
+  color: #000;
+}
+
+.site-footer {
+  background: #000;
+  padding: 40px 16px;
+  display: flex;
+  justify-content: center;
+  gap: 24px;
+  font-size: 14px;
+}
+


### PR DESCRIPTION
## Summary
- rebuild landing page with one-page layout
- add hero section with CTA and features
- integrate generator panel with hook cards
- enhance navigation with sticky scroll behavior
- style page for modern look

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684074833e58832e874d67d54a433548