### PR TITLE
Revamp hook builder output and landing

### DIFF
--- a/readme.MD
+++ b/readme.MD
@@ -1,8 +1,8 @@
 # HookFreak – Video Sales Hook Builder
 
-Bangun skrip video jualan TikTok, Reels, dan Shorts dalam sekali klik. Hasilkan visual hook, teks pembuka, skrip 30 detik, dan saran frame secara langsung.
+Bangun skrip video jualan TikTok, Reels, dan Shorts dalam sekali klik. Hasilkan visual hook, teks pembuka, skrip 30 detik (Hook–Problem–Agitation–Solution–CTA), dan saran frame secara langsung.
 
-Setiap permintaan memberi tiga versi alternatif supaya kamu bisa pilih yang paling pas.
+Setiap permintaan memberi tiga versi alternatif supaya kamu bisa pilih yang paling pas. Inputnya hanya deskripsi produk, target audiens, dan gaya konten.
 
 ## Cara jalan
 1.  `cp .env.example .env.local` lalu isi `GROQ_API_KEY`

--- a/src/lib/groq.ts
+++ b/src/lib/groq.ts
@@ -222,10 +222,17 @@ export interface SalesHook {
   textHook: string;
   script: string;
   frames: string;
+  hookStyle: string;
+  tone: string;
+  niche: string;
 }
 
-export async function generateSalesHooks(desc: string, audience: string, style: string) {
-  const prompt = `Kamu scriptwriter TikTok spesialis jualan. Deskripsi produk: ${desc}. Target audiens: ${audience}. Gaya konten: ${style}. Buat 3 alternatif. Format setiap alternatif:\nVisualHook: <adegan pembuka 1 shot>\nTextHook: <kalimat pembuka>\nScript: <narasi Hook-Problem-Agitation-Solution-CTA maks 30 detik, pisahkan dengan ' -- '>\nFrameSuggestion: <saran visual singkat untuk tiap bagian>. Pisahkan setiap alternatif dengan ====.`;
+export async function generateSalesHooks(
+  desc: string,
+  audience: string,
+  style: string,
+) {
+  const prompt = `Kamu scriptwriter video TikTok spesialis jualan. Deskripsi produk: ${desc}. Target audiens: ${audience}. Gaya konten: ${style}. Hasilkan 3 versi. Format tiap versi:\nVisualHook: <adegan pembuka 1 shot, konkret tanpa CGI>\nTextHook: <kalimat pembuka emosional>\nScript: <narasi mengalir pola Hook-Problem-Agitation-Solution-CTA, pisahkan tiap bagian dengan ' --- ', maksimal 30 detik>\nFrameSuggestion: <saran visual singkat tiap bagian>\nHookStyle: <label pendek jenis visual hook>\nTone: ${style}\nNiche: ${desc}\n====`;
 
   const resp = await fetch("https://api.groq.com/openai/v1/chat/completions", {
     method: "POST",
@@ -256,6 +263,9 @@ export async function generateSalesHooks(desc: string, audience: string, style: 
       textHook: get("TextHook"),
       script: get("Script"),
       frames: get("FrameSuggestion"),
+      hookStyle: get("HookStyle"),
+      tone: get("Tone") || style,
+      niche: get("Niche") || desc,
     } as SalesHook;
   });
 }

--- a/src/pages/builder.tsx
+++ b/src/pages/builder.tsx
@@ -1,6 +1,7 @@
 import Head from "next/head";
 import Navbar from "@/components/Navbar";
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { useRouter } from "next/router";
 
 export default function Builder() {
   const [description, setDescription] = useState("");
@@ -8,6 +9,13 @@ export default function Builder() {
   const [style, setStyle] = useState("soft-sell");
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<any[] | null>(null);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (router.query.desc) setDescription(router.query.desc as string);
+    if (router.query.audience) setAudience(router.query.audience as string);
+    if (router.query.style) setStyle(router.query.style as string);
+  }, [router.query]);
 
   async function handleGenerate(e: React.FormEvent) {
     e.preventDefault();
@@ -86,6 +94,9 @@ export default function Builder() {
                   <p><strong>Teks Hook:</strong> {r.textHook}</p>
                   <p><strong>Script:</strong> {r.script}</p>
                   <p><strong>Frame:</strong> {r.frames}</p>
+                  <p><em>HookStyle:</em> {r.hookStyle}</p>
+                  <p><em>Tone:</em> {r.tone}</p>
+                  <p><em>Niche:</em> {r.niche}</p>
                 </div>
               ))}
             </div>

--- a/src/pages/generator.tsx
+++ b/src/pages/generator.tsx
@@ -84,8 +84,8 @@ export default function Home() {
   return (
     <>
          <Head>
-          <title>HookFreak • AI Viral Hook Generator TikTok</title>
-          <meta name="description" content="Bikin hook video TikTok & Reels viral pakai AI. Gratis, cepat, dan didesain untuk CTR tinggi. Powered by STIDS." />
+          <title>HookFreak • Viral Hook Generator TikTok</title>
+          <meta name="description" content="Bikin hook video TikTok & Reels viral dalam 1 klik. Gratis dan siap pakai." />
           <meta name="keywords" content="hook generator, TikTok hook, AI TikTok content, viral hook tools, konten viral, pembuka video TikTok, kalimat viral, hook reels, CTA TikTok" />
           <meta name="author" content="Stidscom Team" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -202,7 +202,7 @@ export default function Home() {
           )}
         </section>
 
-        <footer className="footer">Made with ❤️ by <a href="https://instagram.com/stidscom" target="_blank" rel="noopener noreferrer">@Stidscom</a> • Powered by Stids AI</footer>
+        <footer className="footer">Made with ❤️ by <a href="https://instagram.com/stidscom" target="_blank" rel="noopener noreferrer">@Stidscom</a></footer>
       </main>
     </>
   );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,143 +1,143 @@
 import Head from "next/head";
 import Navbar from "@/components/Navbar";
-import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
+import { useState } from "react";
+
+const samples = [
+  {
+    visual: "Close up wajah kaget saat lihat bekas jerawat memudar di kaca",
+    text: "Gila, baru seminggu pakai udah kinclong begini!",
+    script:
+      "Wajah kusam bikin minder --- Jerawat bandel susah hilang --- Tiap ngaca rasanya pengen nutup muka --- Serum ini nembusin pori-pori dan redain kemerahan --- Cek link bio biar kamu buktiin sendiri",
+    frame:
+      "1. Close up before-after di kaca\n2. Zoom ke bekas jerawat\n3. Ekspresi frustasi\n4. Teteskan serum dan usap\n5. Ajak klik link di bio",
+  },
+  {
+    visual: "Tumpahan kopi di meja sebelum mengganti tumbler anti tumpah",
+    text: "Pernah kesel gara-gara kopi tumpah di mobil?",
+    script:
+      "Niatnya ngopi malah nyiprat kemana-mana --- Meja kerja jadi kotor dan ngerusak mood --- Setiap hari jadi was-was bawa minuman --- Pake tumbler kunci putar ini, dijamin ga bleber --- Buruan order sebelum stoknya abis",
+    frame:
+      "1. Rekam kopi tumpah\n2. Wajah kesal\n3. Shot close up noda di meja\n4. Tunjukkan tumbler anti tumpah\n5. Shot produk dan info beli",
+  },
+  {
+    visual: "Before-after pakaian kusut lalu halus sekejap pakai steamer",
+    text: "Listrik mati? Ga perlu setrika, ada solusi cepat!",
+    script:
+      "Baju kusut bikin tampilan berantakan --- Setrika butuh waktu lama dan listrik nyala --- Kalau buru-buru malah jadi stress sendiri --- Cukup gantung baju dan nyalakan steamer genggam ini --- Klik tombol beli dan siap tampil rapi",
+    frame:
+      "1. Tunjukkan baju kusut\n2. Ekspresi cemas karena mati listrik\n3. Ambil steamer genggam\n4. Baju langsung rapi\n5. Ajak order sekarang",
+  },
+];
 
 export default function Home() {
-  const [niche, setNiche] = useState("");
-  const [tone, setTone] = useState("fear");
+  const [description, setDescription] = useState("");
+  const [style, setStyle] = useState("storytelling");
+  const [result, setResult] = useState<any[] | null>(null);
   const [loading, setLoading] = useState(false);
-  const [hooks, setHooks] = useState<string[]>([]);
-  const generatorRef = useRef<HTMLDivElement>(null);
-
-  const scrollToGenerator = () => {
-    generatorRef.current?.scrollIntoView({ behavior: "smooth" });
-  };
 
   async function handleGenerate(e: React.FormEvent) {
     e.preventDefault();
-    if (!niche) return;
+    if (!description) return;
     setLoading(true);
-    setHooks([]);
+    setResult(null);
     try {
-      const r = await fetch("/api/generate-hooks", {
+      const r = await fetch("/api/generate-script", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ niche, tone, product: "" }),
+        body: JSON.stringify({ description, audience: "", style }),
       });
       const data = await r.json();
-      setHooks(data.hooks || []);
+      setResult(data.hooks || []);
     } finally {
       setLoading(false);
     }
   }
 
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            entry.target.classList.add("show");
-          }
-        });
-      },
-      { threshold: 0.2 }
-    );
-    const cards = document.querySelectorAll(".hook-card");
-    cards.forEach((c) => observer.observe(c));
-    return () => observer.disconnect();
-  }, [hooks]);
-
   return (
     <>
       <Head>
-        <title>HookFreak</title>
+        <title>HookFreak • Video Sales Hook Builder</title>
         <meta
           name="description"
-          content="Bikin video jualan nancep di detik pertama."
-        />
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
-        <link
-          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap"
-          rel="stylesheet"
+          content="Ubah video jualanmu jadi lebih nendang dalam 5 detik"
         />
       </Head>
       <Navbar />
-
-      <section className="hero-section">
-        <div className="hero-inner">
-          <div className="hero-visual">
-            <img src="https://images.unsplash.com/photo-1517336714731-489689fd1ca8" alt="Laptop 3D" loading="lazy" />
-          </div>
-          <div className="hero-copy">
-            <h1>
-              Bikin opening video <span className="hl">TikTok & Reels</span> yang
-              viral dalam 1 klik
-            </h1>
-            <button className="cta-primary" onClick={scrollToGenerator}>
-              Mulai Gratis Sekarang
+      <main className="main-wrapper">
+        <section className="hero">
+          <h1 className="logo-text">
+            Hook<span>Freak</span>
+          </h1>
+          <p className="subtitle">Video Sales Hook Builder</p>
+          <form onSubmit={handleGenerate} className="hook-form" style={{marginTop:24}}>
+            <label>
+              <span className="form-label">Apa yang kamu jual?</span>
+              <input
+                type="text"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                className="niche-input"
+              />
+            </label>
+            <label>
+              <span className="form-label">Gaya kontenmu apa?</span>
+              <select
+                value={style}
+                onChange={(e) => setStyle(e.target.value)}
+                className="tone-select"
+              >
+                <option value="storytelling">Storytelling</option>
+                <option value="hard-sell">Hard Sell</option>
+                <option value="soft-sell">Soft Sell</option>
+                <option value="humor">Humor</option>
+                <option value="shock">Shock</option>
+                <option value="fomo">FOMO</option>
+                <option value="edukatif">Edukatif</option>
+              </select>
+            </label>
+            <button type="submit" disabled={loading} className="generate-button">
+              {loading ? "Menghasilkan..." : "Generate"}
             </button>
-          </div>
-        </div>
-      </section>
+          </form>
+          {result && (
+            <div className="results" style={{ whiteSpace: "pre-wrap", marginTop:24 }}>
+              {result.map((r, idx) => (
+                <div key={idx} style={{ marginBottom: 24 }}>
+                  <p><strong>Visual Hook:</strong> {r.visualHook}</p>
+                  <p><strong>Teks Hook:</strong> {r.textHook}</p>
+                  <p><strong>Script:</strong> {r.script}</p>
+                  <p><strong>Frame:</strong> {r.frames}</p>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
 
-      <section className="features-section" id="features">
-        <div className="feature">
-          <div className="icon">⚡</div>
-          <p>Pembuatan hook instan</p>
-        </div>
-        <div className="feature">
-          <div className="icon">🧠</div>
-          <p>Varian psikologi viral</p>
-        </div>
-        <div className="feature">
-          <div className="icon">🤖</div>
-          <p>Integrasi AI</p>
-        </div>
-      </section>
-
-      <section id="generator" ref={generatorRef} className="generator-section">
-        <form onSubmit={handleGenerate} className="generator-form">
-          <input
-            type="text"
-            placeholder="Contoh: jualan skincare glowing"
-            value={niche}
-            onChange={(e) => setNiche(e.target.value)}
-          />
-          <select value={tone} onChange={(e) => setTone(e.target.value)}>
-            <option value="fear">Fear / Shock</option>
-            <option value="curiosity">Curiosity</option>
-            <option value="confession">Confession</option>
-            <option value="humor">Humor</option>
-            <option value="affiliate">Affiliate Produk</option>
-          </select>
-          <button type="submit" disabled={loading}>
-            {loading ? "Menghasilkan..." : "Generate"}
-          </button>
-        </form>
-
-        {hooks.length > 0 && (
-          <div className="results-grid">
-            {hooks.map((h, i) => (
-              <div key={i} className="hook-card">
-                <h3 className="hook-title">Hook {i + 1}</h3>
-                <p className="hook-desc">{h}</p>
+        <section style={{marginTop:60}}>
+          <h2 style={{textAlign:'center'}}>Contoh Output</h2>
+          <div className="results" style={{ whiteSpace: "pre-wrap" }}>
+            {samples.map((s, i) => (
+              <div key={i} style={{ marginBottom: 24 }}>
+                <p><strong>Visual Hook:</strong> {s.visual}</p>
+                <p><strong>Teks Hook:</strong> {s.text}</p>
+                <p><strong>Script:</strong> {s.script}</p>
+                <p><strong>Frame:</strong> {s.frame}</p>
               </div>
             ))}
           </div>
-        )}
+        </section>
 
-        <Link href="/builder" className="cta-secondary">
-          Coba Generator Lengkap
-        </Link>
-      </section>
-
-      <footer className="site-footer">
-        <a href="/privacy">Kebijakan Privasi</a>
-        <a href="/terms">Syarat</a>
-        <a href="mailto:hello@hookfreak.com">Kontak</a>
-      </footer>
+        <section style={{marginTop:60, textAlign:'center'}}>
+          <h2>Pilih Jalur Onboarding</h2>
+          <div style={{display:'flex',flexDirection:'column',gap:16,maxWidth:400,margin:'0 auto'}}>
+            <Link href="/builder?style=storytelling" className="generate-button">Saya UGC Creator</Link>
+            <Link href="/builder?style=hard-sell" className="generate-button">Saya Pemilik Brand</Link>
+            <Link href="/builder?style=soft-sell" className="generate-button">Saya Freelancer Marketing</Link>
+          </div>
+        </section>
+      </main>
     </>
   );
 }
+


### PR DESCRIPTION
## Summary
- overhaul sales hook generator to include visual hook prompt, text hook, script with HPAS CTA sections and frame suggestions
- add hook style, tone and niche identifiers
- preload builder values from URL parameters
- redesign landing page with onboarding CTAs and sample outputs
- remove `powered by AI` copy from generator page and update README

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684079218d68832e8c662c403df58e36