### PR TITLE
Add script duration option with UI updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables
+GROQ_API_KEY=your-groq-api-key
+NEXT_PUBLIC_DEFAULT_DURATION=30

--- a/readme.MD
+++ b/readme.MD
@@ -1,21 +1,22 @@
 # HookFreak – Video Sales Hook Builder
 
-Bangun skrip video jualan TikTok, Reels, dan Shorts dalam sekali klik. Hasilkan visual hook, teks pembuka, skrip 30 detik, dan saran frame secara langsung.
+Bangun skrip video jualan TikTok, Reels, dan Shorts dalam sekali klik. Hasilkan visual hook, teks pembuka, skrip berdurasi fleksibel, dan saran frame secara langsung.
 
 Setiap permintaan memberi tiga versi alternatif supaya kamu bisa pilih yang paling pas.
 
 **Fitur Utama:**
 * **Visual Hook Prompt:** Ide adegan pembuka yang kuat & bisa langsung direkam.
 * **Teks Hook Nendang:** Kalimat pembuka subtitle/VO yang bikin berhenti scroll.
-* **Skrip Video 30 Detik:** Struktur Hook-Problem-Agitation-Solution-CTA yang menjual.
+* **Skrip Video Sesuai Durasi:** Struktur Hook-Problem-Agitation-Solution-CTA dengan panjang yang bisa diatur.
 * **Saran Frame Praktis:** Ide visual per bagian skrip untuk memudahkan produksi.
 * **3 Alternatif Sekali Generate:** Pilih gaya yang paling cocok untuk brand-mu.
 
 ## Cara jalan
 1.  Salin file `.env.example` menjadi `.env.local` (`cp .env.example .env.local`).
 2.  Isi `GROQ_API_KEY` di dalam `.env.local` dengan API key Groq Anda.
-3.  Install dependencies: `npm i`
-4.  Jalankan server development: `npm run dev`
+3.  Atur `NEXT_PUBLIC_DEFAULT_DURATION` jika ingin mengubah durasi script default (opsional).
+4.  Install dependencies: `npm i`
+5.  Jalankan server development: `npm run dev`
 
 Aplikasi akan berjalan di `http://localhost:3000`.
 Anda bisa langsung buka halaman utama untuk mencoba generator singkat, atau ke `/builder` untuk fitur input yang lebih lengkap.

--- a/src/lib/groq.ts
+++ b/src/lib/groq.ts
@@ -15,12 +15,14 @@ export interface SalesAlternative {
 export async function generateCompleteSalesHooks(
   productDesc: string,
   audience: string,
-  style: string
+  style: string,
+  duration?: number
 ): Promise<SalesAlternative[]> {
   // Default values jika input tidak lengkap
   const finalProductDesc = productDesc || "skincare pencerah wajah";
   const finalAudience = audience || "wanita usia 20-35 tahun yang aktif di sosial media dan tertarik dengan perawatan kulit praktis";
   const finalStyle = style || "storytelling edukatif";
+  const finalDuration = duration || Number(process.env.NEXT_PUBLIC_DEFAULT_DURATION) || 30;
 
   const prompt = `
 Kamu adalah seorang scriptwriter video TikTok profesional dengan spesialisasi membuat konten jualan yang viral dan sangat efektif. Klienmu adalah kreator konten dan marketer yang butuh skrip siap pakai, bukan ide abstrak atau deskripsi umum. Outputmu harus langsung usable.
@@ -35,7 +37,7 @@ VisualHook: [Deskripsi adegan pembuka 1-2 detik yang kuat secara visual, konkret
 
 TextHook: [Satu kalimat pembuka yang emosional, provokatif, atau sangat membuat penasaran. Cocok untuk subtitle atau voiceover. Gaya bahasa harus menyesuaikan gaya konten yang diminta dan punya efek interrupt kuat. Contoh: "STOP scroll kalau lo masih jerawatan di usia 25!"; "Gue kira ini gimmick, ternyata..."; "Rahasia glow up modal 50 ribu?"]
 
-Script: [Narasi video lengkap (maksimal 30 detik) dengan struktur Hook - Problem - Agitation - Solution - CTA. Tulis sebagai PARAGRAF yang mengalir alami dan enak didengar/dibaca, BUKAN outline poin-poin. Pisahkan setiap bagian (Hook, Problem, Agitation, Solution, CTA) secara eksplisit dengan ' -- ' (spasi, dua strip, spasi). Gaya bahasa percakapan sehari-hari, sesuaikan dengan gaya konten dan target audiens.
+Script: [Narasi video lengkap (maksimal ${finalDuration} detik) dengan struktur Hook - Problem - Agitation - Solution - CTA. Tulis sebagai PARAGRAF yang mengalir alami dan enak didengar/dibaca, BUKAN outline poin-poin. Pisahkan setiap bagian (Hook, Problem, Agitation, Solution, CTA) secara eksplisit dengan ' -- ' (spasi, dua strip, spasi). Gaya bahasa percakapan sehari-hari, sesuaikan dengan gaya konten dan target audiens.
 Contoh struktur internal (jangan tampilkan ini di output, hanya sebagai panduanmu):
 Hook: (Lanjutkan atau elaborasi dari TextHook, tarik perhatian lebih dalam)
 --
@@ -170,3 +172,25 @@ export async function generateSalesHooks(desc: string, audience: string, style: 
     // ... implementasi lama ...
 }
 */
+
+// Placeholder to satisfy build for legacy API routes
+export async function generateBatchPack(
+  brand: string,
+  product: string,
+  audience: string,
+  count = 10
+) {
+  throw new Error("generateBatchPack is not implemented");
+}
+
+export async function generateHooks(
+  niche: string,
+  tone: string,
+  product?: string
+) {
+  throw new Error("generateHooks is not implemented");
+}
+
+export async function generateHookScenes(niche: string, tone: string) {
+  throw new Error("generateHookScenes is not implemented");
+}

--- a/src/pages/api/generate-script.ts
+++ b/src/pages/api/generate-script.ts
@@ -14,13 +14,14 @@ export default async function handler(
     description = "", // Deskripsi produk
     audience = "",    // Target audiens
     style = "",       // Gaya konten, e.g., "storytelling", "hard-sell"
+    duration = null    // Durasi maksimum script
   } = req.body;
 
   // Tidak perlu validasi input kosong di sini jika kita ingin mengandalkan default
   // di generateCompleteSalesHooks untuk fitur "lihat hasil nyata dalam 5 detik".
 
   try {
-    const alternatives: SalesAlternative[] = await generateCompleteSalesHooks(description, audience, style); //
+    const alternatives: SalesAlternative[] = await generateCompleteSalesHooks(description, audience, style, duration ? Number(duration) : undefined); //
     // Kirim semua alternatif ke client
     res.status(200).json({ alternatives });
   } catch (err: any) {

--- a/src/pages/builder.tsx
+++ b/src/pages/builder.tsx
@@ -33,6 +33,7 @@ export default function Builder() {
   const [productDesc, setProductDesc] = useState(""); //
   const [targetAudience, setTargetAudience] = useState(""); //
   const [contentStyle, setContentStyle] = useState("storytelling"); // Default style
+  const [duration, setDuration] = useState(30);
   const [loading, setLoading] = useState(false); //
   const [results, setResults] = useState<SalesAlternative[] | null>(null); //
   const [error, setError] = useState<string | null>(null);
@@ -48,15 +49,15 @@ export default function Builder() {
       if (persona === "ugc") {
         setProductDesc(productDesc || "Produk review dari brand XYZ (kosmetik/fashion/gadget)");
         setTargetAudience(targetAudience || "Anak muda Gen Z yang suka konten otentik dan review jujur");
-        setContentStyle(style || "storytelling");
+        setContentStyle((style as string) || "storytelling");
       } else if (persona === "brand") {
         setProductDesc(productDesc || "Produk unggulan brand kami [Nama Brand]");
         setTargetAudience(targetAudience || "Target market spesifik brand kami [Misal: Ibu muda pekerja]");
-        setContentStyle(style || "soft-sell");
+        setContentStyle((style as string) || "soft-sell");
       } else if (persona === "freelancer") {
         setProductDesc(productDesc || "Produk klien [Nama Klien/Jenis Industri]");
         setTargetAudience(targetAudience || "Target audiens klien");
-        setContentStyle(style || "hard-sell");
+        setContentStyle((style as string) || "hard-sell");
       }
     }
   }, [router.isReady, router.query, productDesc, targetAudience, contentStyle]); // Added dependencies
@@ -79,6 +80,7 @@ export default function Builder() {
           description: productDesc,
           audience: targetAudience,
           style: contentStyle,
+          duration,
         }),
       });
       if (!r.ok) {
@@ -151,6 +153,14 @@ export default function Builder() {
                  <option value="problem-solution">Problem/Solution (Masalah & Solusi)</option>
                 <option value="testimonial">Testimonial (Review Jujur)</option>
                 <option value="unboxing">Unboxing Keren</option>
+              </select>
+            </label>
+            <label>
+              <span className="form-label">Durasi Maksimal Skrip</span>
+              <select value={duration} onChange={(e) => setDuration(parseInt(e.target.value))} className="tone-select">
+                <option value={15}>15 detik</option>
+                <option value={30}>30 detik</option>
+                <option value={60}>60 detik</option>
               </select>
             </label>
             <button type="submit" disabled={loading} className="generate-button"> {/* */}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -28,6 +28,7 @@ const formatScriptForLandingDisplay = (script: string) => {
 export default function HomePage() {
   const [productInput, setProductInput] = useState("");
   const [styleInput, setStyleInput] = useState("storytelling");
+  const [durationInput, setDurationInput] = useState(30);
   const [loading, setLoading] = useState(false); //
   const [firstResult, setFirstResult] = useState<SalesAlternative | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -43,9 +44,10 @@ export default function HomePage() {
         method: "POST", //
         headers: { "Content-Type": "application/json" }, //
         body: JSON.stringify({ //
-          description: productInput, 
-          audience: "", 
-          style: styleInput, 
+          description: productInput,
+          audience: "",
+          style: styleInput,
+          duration: durationInput,
         }),
       });
       if (!r.ok) {
@@ -98,7 +100,7 @@ export default function HomePage() {
     <>
       <Head>
         <title>HookFreak – Video Sales Hook Builder (TikTok, Reels, Shorts)</title>
-        <meta name="description" content="Bikin skrip video jualan TikTok, Reels, dan Shorts yang nancep di detik pertama. Hasilkan visual hook, teks pembuka, skrip 30 detik, dan saran frame dalam 1 klik!" />
+        <meta name="description" content="Bikin skrip video jualan TikTok, Reels, dan Shorts yang nancep di detik pertama. Hasilkan visual hook, teks pembuka, skrip sesuai durasi, dan saran frame dalam 1 klik!" />
         <meta name="keywords" content="video sales hook, tiktok script generator, reels script, shorts script, content creator tool, marketing video, hook generator" />
         <link rel="preconnect" href="https://fonts.googleapis.com" /> {/* */}
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" /> {/* */}
@@ -118,7 +120,7 @@ export default function HomePage() {
         <section className="hero-new">
           <div className="hero-content-new">
             <h1>Stop Bikin Konten Jualan <span className="highlight">Ngebosenin</span>.</h1>
-            <p className="subheadline">HookFreak bantu kamu bikin <strong className="highlight">visual hook, teks pembuka, skrip 30 detik, dan ide frame</strong> video TikTok & Reels yang nancep di detik pertama. Sekali klik, tiga alternatif langsung jadi!</p>
+            <p className="subheadline">HookFreak bantu kamu bikin <strong className="highlight">visual hook, teks pembuka, skrip sesuai durasi, dan ide frame</strong> video TikTok & Reels yang nancep di detik pertama. Sekali klik, tiga alternatif langsung jadi!</p>
             <form onSubmit={handleQuickGenerate} className="hero-form">
               <input
                 type="text"
@@ -134,6 +136,11 @@ export default function HomePage() {
                 <option value="shock">Gaya: Shock</option>
                 <option value="fomo">Gaya: FOMO</option>
                 <option value="edukatif">Gaya: Edukatif</option>
+              </select>
+              <select value={durationInput} onChange={(e) => setDurationInput(parseInt(e.target.value))}>
+                <option value={15}>Durasi: 15 detik</option>
+                <option value={30}>Durasi: 30 detik</option>
+                <option value={60}>Durasi: 60 detik</option>
               </select>
               <button type="submit" disabled={loading}>
                 {loading ? "Lagi Diracik..." : "🧪 Lihat Hasil Nyata (Gratis!)"}


### PR DESCRIPTION
## Summary
- allow configuration of default duration via new `NEXT_PUBLIC_DEFAULT_DURATION` env variable
- expose `.env.example` with the new variable
- update landing page text and form to include duration selection
- update builder page with duration option
- support duration parameter in API and Groq prompt
- stub legacy functions to satisfy build

## Testing
- `npm i`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68407b651804832e898a9ce673e96c8d