### PR TITLE
Fix crash when Firebase config absent

### DIFF
--- a/src/components/AuthProvider.tsx
+++ b/src/components/AuthProvider.tsx
@@ -21,6 +21,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+    if (!auth) {
+      setLoading(false);
+      return;
+    }
     const unsub = onAuthStateChanged(auth, (u) => {
       setUser(u);
       setLoading(false);
@@ -29,10 +33,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const login = async () => {
+    if (!auth) return;
     await signInWithPopup(auth, googleProvider);
   };
 
   const logout = async () => {
+    if (!auth) return;
     await signOut(auth);
   };
 


### PR DESCRIPTION
## Summary
- avoid calling firebase auth when configuration isn't provided

## Testing
- `npm install` *(fails: ENOTEMPTY / network issues)*


------
https://chatgpt.com/codex/tasks/task_e_684137f2b870832ea85060f0f796a7fa