### PR TITLE
Revamp style token usage

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -5,21 +5,36 @@ import { SpeedInsights } from "@vercel/speed-insights/next"; // Tambahan ini!
 import { AuthProvider } from "@/components/AuthProvider";
 
 export default function App({ Component, pageProps }: AppProps) {
-  const highlight = process.env.NEXT_PUBLIC_HIGHLIGHT_COLOR || '#39ff14';
-  const gradient = process.env.NEXT_PUBLIC_GRADIENT || 'linear-gradient(90deg,#39ff14,#00ffe6)';
+  const tokens = {
+    highlight: process.env.NEXT_PUBLIC_HIGHLIGHT_COLOR || '#39ff14',
+    gradient: process.env.NEXT_PUBLIC_GRADIENT || 'linear-gradient(90deg,#39ff14,#00ffe6)',
+    bg: process.env.NEXT_PUBLIC_BG || '#000',
+    card: process.env.NEXT_PUBLIC_CARD || '#131313',
+    text: process.env.NEXT_PUBLIC_TEXT || '#f0f0f0',
+    muted: process.env.NEXT_PUBLIC_MUTED || '#b0b0b0',
+    radius: Number(process.env.NEXT_PUBLIC_RADIUS) || 12,
+    shadow: process.env.NEXT_PUBLIC_SHADOW || '0 4px 15px rgba(57,255,20,.35)',
+  };
+
   return (
     <>
       <style jsx global>{`
         :root {
-          --highlight-color: ${highlight};
-          --highlight-gradient: ${gradient};
+          --highlight-color: ${tokens.highlight};
+          --highlight-gradient: ${tokens.gradient};
+          --bg-color: ${tokens.bg};
+          --card-color: ${tokens.card};
+          --text-color: ${tokens.text};
+          --muted-color: ${tokens.muted};
+          --radius: ${tokens.radius}px;
+          --shadow: ${tokens.shadow};
         }
       `}</style>
       <AuthProvider>
         <Component {...pageProps} />
       </AuthProvider>
       <Analytics />
-      <SpeedInsights /> {/* Tambahkan komponen ini */}
+      <SpeedInsights />
     </>
   );
 }

--- a/src/pages/builder.tsx
+++ b/src/pages/builder.tsx
@@ -214,60 +214,50 @@ export default function Builder(){
 
       {/* ---------- STYLE (token based) ---------- */}
       <style jsx global>{`
-        :root{
-          --clr-primary:${TOKENS.COLOR_PRIMARY};
-          --clr-gradient:${TOKENS.COLOR_GRADIENT};
-          --clr-bg:${TOKENS.COLOR_BG};
-          --clr-card:${TOKENS.COLOR_CARD};
-          --clr-text:${TOKENS.COLOR_TEXT};
-          --clr-muted:${TOKENS.COLOR_MUTED};
-          --radius:${TOKENS.RADIUS}px;
-          --shadow:${TOKENS.SHADOW_ELEVATE};
-        }
         *{box-sizing:border-box}
-        body{margin:0;font-family:Inter,system-ui;background:var(--clr-bg);color:var(--clr-text)}
+        body{margin:0;font-family:Inter,system-ui;background:var(--bg-color);color:var(--text-color)}
         a{text-decoration:none;color:inherit}
         .hl{
-          background:var(--clr-gradient);
+          background:var(--highlight-gradient);
           -webkit-background-clip:text;
           color:transparent;
         }
         .btn{display:inline-block;padding:.85rem 1.6rem;border-radius:6px;font-weight:700;transition:.2s}
-        .btn.primary{background:var(--clr-gradient);color:#000;box-shadow:var(--shadow)}
+        .btn.primary{background:var(--highlight-gradient);color:#000;box-shadow:var(--shadow)}
         .btn.ghost{background:rgba(255,255,255,.07)}
         .btn.primary:disabled{opacity:.6;cursor:not-allowed}
 
         .nav{display:flex;justify-content:space-between;align-items:center;
              padding:1.15rem 1.4rem;background:#080808;position:sticky;top:0;
              border-bottom:1px solid #1a1a1a;z-index:60}
-        .logo{font-weight:900;font-size:1.4rem;color:var(--clr-primary)}
+        .logo{font-weight:900;font-size:1.4rem;color:var(--highlight-color)}
 
         .wrap{margin:0 auto;padding:4rem 1rem}
         .hero{text-align:center;margin-bottom:3rem}
         .hero h1{font-size:2rem;font-weight:900;margin:.4rem 0}
-        .hero p{color:var(--clr-muted)}
+        .hero p{color:var(--muted-color)}
 
-        .card{background:var(--clr-card);border:1px solid #242424;border-radius:var(--radius);
+        .card{background:var(--card-color);border:1px solid #242424;border-radius:var(--radius);
               padding:2rem 1.6rem;transition:.25s}
-        .card:hover{border-color:var(--clr-primary)}
+        .card:hover{border-color:var(--highlight-color)}
 
         .form{display:flex;flex-direction:column;gap:1.2rem}
         .form input,.form select{
           width:100%;padding:.82rem;border-radius:6px;border:1px solid #333;
-          background:#0b0b0b;color:var(--clr-text)
+          background:#0b0b0b;color:var(--text-color)
         }
         .err{color:#ff6b6b;margin-top:1rem;text-align:center}
 
         .results h2{text-align:center;margin:4rem 0 2rem;font-size:1.5rem}
         .alt header{display:flex;justify-content:space-between;align-items:center;margin-bottom:.9rem}
-        .copy{background:none;border:none;color:var(--clr-text);cursor:pointer}
+        .copy{background:none;border:none;color:var(--text-color);cursor:pointer}
 
         .part{margin-top:1.35rem}
-        .part b{display:block;color:var(--clr-primary);margin-bottom:.35rem}
-        .script{border-left:3px solid var(--clr-primary);padding-left:.9rem;background:#151515}
-        .script-list{list-style:none;margin:0;border-left:3px solid var(--clr-primary);padding-left:.9rem;background:#151515}
+        .part b{display:block;color:var(--highlight-color);margin-bottom:.35rem}
+        .script{border-left:3px solid var(--highlight-color);padding-left:.9rem;background:#151515}
+        .script-list{list-style:none;margin:0;border-left:3px solid var(--highlight-color);padding-left:.9rem;background:#151515}
         .sr{margin-bottom:.8rem}
-        .sr strong{color:var(--clr-primary);display:block;margin-bottom:.2rem}
+        .sr strong{color:var(--highlight-color);display:block;margin-bottom:.2rem}
 
         @media(max-width:480px){
           .hero h1{font-size:1.55rem}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -159,45 +159,36 @@ export default function HomePage() {
 
       {/* ------------ STYLE ------------- */}
       <style jsx global>{`
-        :root{
-          --clr-primary:${PRIMARY_COLOR};
-          --clr-gradient:${GRADIENT};
-          --clr-bg:#000;
-          --clr-card:#131313;
-          --clr-text:#f0f0f0;
-          --clr-muted:#b0b0b0;
-          --radius:12px;
-        }
         *,*::before,*::after{box-sizing:border-box;}
-        body{margin:0;font-family:Inter,system-ui;background:var(--clr-bg);color:var(--clr-text)}
+        body{margin:0;font-family:Inter,system-ui;background:var(--bg-color);color:var(--text-color)}
         a{text-decoration:none;color:inherit}
 
         /* buttons */
         .btn{display:inline-block;padding:.9rem 1.8rem;border-radius:6px;font-weight:700;transition:.2s}
-        .btn.primary{background:var(--clr-gradient);color:#000;box-shadow:0 4px 15px rgba(57,255,20,.3)}
+        .btn.primary{background:var(--highlight-gradient);color:#000;box-shadow:0 4px 15px rgba(57,255,20,.3)}
         .btn.primary:hover{transform:translateY(-2px)}
         .btn.ghost{background:rgba(255,255,255,.06)}
         .btn.center{margin:3rem auto 0;display:block;width:max-content}
 
         /* nav */
         .nav{display:flex;justify-content:space-between;align-items:center;padding:1.2rem 1.6rem;background:#080808;position:sticky;top:0;z-index:50;border-bottom:1px solid #1a1a1a}
-        .logo{font-size:1.5rem;font-weight:900;color:var(--clr-primary)}
-        .logo span{color:var(--clr-text)}
+        .logo{font-size:1.5rem;font-weight:900;color:var(--highlight-color)}
+        .logo span{color:var(--text-color)}
         
         /* hero */
         .hero{text-align:center;padding:4rem 1.5rem;position:relative}
-        .hero::before{content:"";position:absolute;inset:0;background:radial-gradient(circle,var(--clr-primary)12%,transparent 60%);opacity:.05;pointer-events:none}
+        .hero::before{content:"";position:absolute;inset:0;background:radial-gradient(circle,var(--highlight-color)12%,transparent 60%);opacity:.05;pointer-events:none}
         .hero h1{font-size:2.2rem;font-weight:900;margin-bottom:1.2rem}
-        .hero p{max-width:640px;margin:0 auto 2rem;line-height:1.7;color:var(--clr-muted)}
+        .hero p{max-width:640px;margin:0 auto 2rem;line-height:1.7;color:var(--muted-color)}
         .hl{
-          background:var(--clr-gradient);
+          background:var(--highlight-gradient);
           -webkit-background-clip:text;
           color:transparent;
         }
 
         /* sections */
         .section{padding:4rem 1.5rem}
-        .section.dark{background:#000}
+        .section.dark{background:var(--bg-color)}
         .section h2{text-align:center;font-size:2rem;margin-bottom:2.5rem}
 
         /* grid */
@@ -206,30 +197,30 @@ export default function HomePage() {
         @media(min-width:768px){.g3{grid-template-columns:repeat(3,1fr)}}
 
         /* cards */
-        .card{background:var(--clr-card);border:1px solid #222;border-radius:var(--radius);padding:2rem 1.5rem;transition:.25s}
-        .card:hover{transform:translateY(-4px);border-color:var(--clr-primary)}
+        .card{background:var(--card-color);border:1px solid #222;border-radius:var(--radius);padding:2rem 1.5rem;transition:.25s}
+        .card:hover{transform:translateY(-4px);border-color:var(--highlight-color)}
         .feature .icon{font-size:2.4rem;margin-bottom:1.2rem}
         .feature h3{font-size:1.25rem;margin-bottom:.7rem}
-        .feature p{color:var(--clr-muted);line-height:1.6}
+        .feature p{color:var(--muted-color);line-height:1.6}
 
-        .persona{color:var(--clr-text);display:flex;flex-direction:column;height:100%}
+        .persona{color:var(--text-color);display:flex;flex-direction:column;height:100%}
         .persona h3{font-size:1.25rem;margin-bottom:1rem}
         .persona .icon{margin-right:.4rem}
-        .persona p{color:var(--clr-muted);flex-grow:1;line-height:1.6;margin-bottom:1rem}
-        .persona .cta{color:var(--clr-primary);font-weight:700}
+        .persona p{color:var(--muted-color);flex-grow:1;line-height:1.6;margin-bottom:1rem}
+        .persona .cta{color:var(--highlight-color);font-weight:700}
 
         /* example */
         .example header{display:flex;justify-content:space-between;align-items:center;margin-bottom:1rem;border-bottom:1px solid #222;padding-bottom:.8rem}
         .example h4{font-size:1.1rem;margin:0}
-        .tag{background:rgba(57,255,20,.12);color:var(--clr-primary);padding:.25rem .6rem;border-radius:16px;font-size:.8rem}
+        .tag{background:rgba(57,255,20,.12);color:var(--highlight-color);padding:.25rem .6rem;border-radius:16px;font-size:.8rem}
         .part{margin-top:1.2rem}
-        .part b{display:block;color:var(--clr-primary);margin-bottom:.4rem}
-        .script{border-left:3px solid var(--clr-primary);padding-left:.8rem;background:#151515}
+        .part b{display:block;color:var(--highlight-color);margin-bottom:.4rem}
+        .script{border-left:3px solid var(--highlight-color);padding-left:.8rem;background:#151515}
         .script-row{margin-bottom:1rem;line-height:1.6}
-        .script-row strong{color:var(--clr-primary);display:block;margin-bottom:.2rem}
+        .script-row strong{color:var(--highlight-color);display:block;margin-bottom:.2rem}
 
         /* footer */
-        .footer{text-align:center;padding:3rem 1.5rem;border-top:1px solid #1a1a1a;color:var(--clr-muted)}
+        .footer{text-align:center;padding:3rem 1.5rem;border-top:1px solid #1a1a1a;color:var(--muted-color)}
 
         /* responsive tweaks */
         @media(max-width:480px){

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -24,6 +24,8 @@ export default function Login() {
     background: 'linear-gradient(135deg, #000000 0%, #111827 50%, #0f172a 100%)',
   }
 
+  const highlight = 'var(--highlight-color)'
+
   const card: CSSProperties = {
     width: '100%',
     maxWidth: 420,
@@ -91,7 +93,7 @@ export default function Login() {
       <div style={card}>
         <header>
           <h1 style={heading}>
-            Masuk ke <span style={{ color: '#22c55e' }}>HookFreak</span>
+            Masuk ke <span style={{ color: highlight }}>HookFreak</span>
           </h1>
           <p style={subtext}>Satu klik untuk mulai membangun hook viral</p>
         </header>
@@ -105,7 +107,7 @@ export default function Login() {
         >
           {loading ? (
             <svg
-              style={{ height: 20, width: 20, animation: 'spin 1s linear infinite', color: '#22c55e' }}
+              style={{ height: 20, width: 20, animation: 'spin 1s linear infinite', color: highlight }}
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
               viewBox="0 0 24 24"

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,6 +1,13 @@
 :root {
     --font-main: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     --highlight-color: #39ff14;
+    --highlight-gradient: linear-gradient(90deg,#39ff14,#00ffe6);
+    --bg-color: #000;
+    --card-color: #131313;
+    --text-color: #f0f0f0;
+    --muted-color: #b0b0b0;
+    --radius: 12px;
+    --shadow: 0 4px 15px rgba(57,255,20,.35);
   }
   
   * {
@@ -9,11 +16,10 @@
   }
   
   body {
-    /* font-family: ; */
     margin: 0;
     padding: 0;
-    background-color: #000;
-    color: white;
+    background-color: var(--bg-color);
+    color: var(--text-color);
     font-size: 16px;
     line-height: 1.6;
   }
@@ -63,7 +69,7 @@
   .form-section {
     width: 100%;
     max-width: 600px;
-    background: #000; box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+    background: var(--card-color); box-shadow: 0 2px 6px rgba(0,0,0,0.3);
     padding: 24px;
     border-radius: 16px;
     /* box-shadow: 0 0 20px rgba(0, 255, 128, 0.1); */
@@ -103,7 +109,7 @@
   
   form input,
   form select {
-    background: #000; box-shadow: 0 1px 3px rgba(0,0,0,0.4);
+    background: var(--bg-color); box-shadow: 0 1px 3px rgba(0,0,0,0.4);
     border: 1px solid #525252;
     color: rgb(255, 255, 255);
   }
@@ -207,7 +213,7 @@
   }
   
   .tone-select {
-    background: #000; box-shadow: 0 1px 3px rgba(0,0,0,0.4);
+    background: var(--bg-color); box-shadow: 0 1px 3px rgba(0,0,0,0.4);
     border: 1px solid #525252;
     border-radius: 10px;
     color: white;
@@ -225,7 +231,7 @@
   }
   
   .niche-input {
-    background: #000; box-shadow: 0 1px 3px rgba(0,0,0,0.4);
+    background: var(--bg-color); box-shadow: 0 1px 3px rgba(0,0,0,0.4);
     border: 1px solid #525252;
     border-radius: 10px;
     color: white;
@@ -295,7 +301,7 @@
   }
   
   .community-cta:hover {
-    background: #000; box-shadow: 0 1px 3px rgba(0,0,0,0.4);
+    background: var(--bg-color); box-shadow: 0 1px 3px rgba(0,0,0,0.4);
     color: #606060;
   }
     /* Tips berganti */
@@ -303,7 +309,7 @@
         margin-top: 9px;
         font-size: 0.80rem;
         color: #ffffff67;
-        background: #000; box-shadow: 0 1px 3px rgba(0,0,0,0.4);
+        background: var(--bg-color); box-shadow: 0 1px 3px rgba(0,0,0,0.4);
         padding: 10px 14px;
         border-radius: 8px;
         font-style: italic;


### PR DESCRIPTION
## Summary
- define theme tokens globally in `_app`
- apply tokens consistently across pages
- update login screen to use highlight variable
- adjust global styles to read from tokens

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841464bf3ac832eaed62ba8282bce65